### PR TITLE
fix: outcome counting, rework detection, and decision quality scoring

### DIFF
--- a/src/extractors/convergence.test.ts
+++ b/src/extractors/convergence.test.ts
@@ -23,6 +23,33 @@ function createSessionFile(messages: Array<{ type: string; content: string }>): 
   return filePath;
 }
 
+/** Create a session JSONL with raw JSON lines (for tool_use blocks) */
+function createRawSessionFile(lines: object[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "pulse-conv-test-"));
+  tmpDirs.push(dir);
+  const filePath = join(dir, "session.jsonl");
+  writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join("\n") + "\n");
+  tmpFiles.push(filePath);
+  return filePath;
+}
+
+function toolUseMsg(toolName: string, input: Record<string, unknown>): object {
+  return {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", name: toolName, input }],
+    },
+  };
+}
+
+function userMsg(text: string): object {
+  return {
+    type: "user",
+    message: { role: "user", content: text },
+  };
+}
+
 afterEach(() => {
   for (const f of tmpFiles) { try { unlinkSync(f); } catch {} }
   for (const d of tmpDirs) { try { rmdirSync(d); } catch {} }
@@ -57,5 +84,133 @@ describe("extractConvergence", () => {
     assert.equal(result.exchanges, 2);
     // Only the real "wrong, revert" message counts as rework
     assert.equal(result.reworkInstances, 1);
+  });
+
+  it("counts Write tool calls as outcomes", () => {
+    const session = createRawSessionFile([
+      userMsg("create two files"),
+      toolUseMsg("Write", { file_path: "/tmp/a.ts", content: "a" }),
+      toolUseMsg("Write", { file_path: "/tmp/b.ts", content: "b" }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+  });
+
+  it("counts Edit tool calls as outcomes, deduplicating by file path", () => {
+    const session = createRawSessionFile([
+      userMsg("fix the bug"),
+      toolUseMsg("Edit", { file_path: "/tmp/a.ts", old_string: "x", new_string: "y" }),
+      toolUseMsg("Edit", { file_path: "/tmp/a.ts", old_string: "y", new_string: "z" }),
+      toolUseMsg("Edit", { file_path: "/tmp/b.ts", old_string: "1", new_string: "2" }),
+    ]);
+    const result = extractConvergence(session, 0);
+    // 2 unique files edited, not 3
+    assert.equal(result.outcomes, 2);
+  });
+
+  it("counts git commit Bash commands as outcomes", () => {
+    const session = createRawSessionFile([
+      userMsg("commit the changes"),
+      toolUseMsg("Bash", { command: 'git commit -m "fix: something"' }),
+      toolUseMsg("Bash", { command: 'git add . && git commit -m "feat: other"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+  });
+
+  it("counts gh pr create and gh issue create as outcomes", () => {
+    const session = createRawSessionFile([
+      userMsg("create a PR and an issue"),
+      toolUseMsg("Bash", { command: 'gh pr create --title "fix" --body "desc"' }),
+      toolUseMsg("Bash", { command: 'gh issue create --title "bug" --body "desc"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+  });
+
+  it("combines file edits, commits, and PRs without double-counting files", () => {
+    const session = createRawSessionFile([
+      userMsg("fix and ship"),
+      toolUseMsg("Edit", { file_path: "/tmp/a.ts", old_string: "x", new_string: "y" }),
+      toolUseMsg("Write", { file_path: "/tmp/b.ts", content: "new" }),
+      toolUseMsg("Bash", { command: 'git commit -m "fix: a bug"' }),
+      toolUseMsg("Bash", { command: 'gh pr create --title "fix"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    // 2 unique files + 1 commit + 1 PR = 4
+    assert.equal(result.outcomes, 4);
+  });
+
+  it("floors outcomes at 1 when session has no deliverables", () => {
+    const session = createRawSessionFile([
+      userMsg("explain how this works"),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 1);
+  });
+
+  it("uses max of session outcomes and filesChanged", () => {
+    // Session has 1 Write, but git shows 5 files changed
+    const session = createRawSessionFile([
+      userMsg("do stuff"),
+      toolUseMsg("Write", { file_path: "/tmp/a.ts", content: "a" }),
+    ]);
+    const result = extractConvergence(session, 5);
+    assert.equal(result.outcomes, 5);
+  });
+});
+
+describe("rework detection", () => {
+  it("detects 'actually' followed by punctuation (not just comma/space)", () => {
+    const session = createSessionFile([
+      { type: "user", content: "actually... let me rethink this" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 1);
+  });
+
+  it("detects 'try again' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "that didn't work, try again" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 1);
+  });
+
+  it("detects 'wait' and 'hold on' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "wait, that's not right" },
+      { type: "user", content: "hold on, I changed my mind" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("detects 'never mind' and 'scratch that' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "never mind that approach" },
+      { type: "user", content: "scratch that, do it differently" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("detects 'not what I meant' and 'not correct' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "that's not what I meant" },
+      { type: "user", content: "that's not correct" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("does not false-positive on normal instructions", () => {
+    const session = createSessionFile([
+      { type: "user", content: "add a login form to the page" },
+      { type: "user", content: "now add validation for the email field" },
+      { type: "user", content: "can you also add a password strength indicator" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 0);
   });
 });

--- a/src/extractors/convergence.ts
+++ b/src/extractors/convergence.ts
@@ -7,6 +7,12 @@ interface SessionMessage {
   message?: { role?: string; content?: unknown };
 }
 
+interface ToolUseBlock {
+  type: "tool_use";
+  name: string;
+  input: Record<string, unknown>;
+}
+
 /** Time window extracted from the session JSONL */
 export interface SessionTimeWindow {
   start: string | null;
@@ -27,15 +33,17 @@ export function extractConvergence(
 ): ConvergenceSignal {
   let exchanges = 0;
   let reworkInstances = 0;
+  let sessionOutcomes = 0;
 
   if (sessionPath) {
     const parsed = parseSessionMessages(sessionPath);
     exchanges = parsed.exchanges;
     reworkInstances = parsed.reworkInstances;
+    sessionOutcomes = parsed.outcomes;
   }
 
-  // Outcomes: at minimum, files changed in git. Floor at 1 to avoid division by zero.
-  const outcomes = Math.max(filesChanged, 1);
+  // Outcomes: max of session-derived outcomes and git filesChanged. Floor at 1 to avoid division by zero.
+  const outcomes = Math.max(sessionOutcomes, filesChanged, 1);
   const rate = exchanges > 0 ? round(exchanges / outcomes, 2) : 0;
   const reworkPercent = exchanges > 0 ? round((reworkInstances / exchanges) * 100, 1) : 0;
 
@@ -133,22 +141,38 @@ const REWORK_PATTERNS = [
   /\bno[, ]+not that\b/i,
   /\bwrong\b/i,
   /\binstead\b/i,
-  /\bactually[, ]+/i,
+  /\bactually\b/i,
   /\bdon'?t do\b/i,
   /\bstop\b/i,
   /\bgo back\b/i,
   /\bthat'?s not what/i,
+  /\bthat'?s not correct/i,
+  /\bnot what I\b/i,
   /\bretry\b/i,
+  /\btry again\b/i,
   /\bredo\b/i,
   /\broll ?back\b/i,
+  /\bwait[,.]?\s/i,
+  /\bhold on\b/i,
+  /\bnever mind\b/i,
+  /\bscratch that\b/i,
 ];
+
+const GIT_COMMIT_RE = /\bgit\s+commit\b/;
+const GH_PR_CREATE_RE = /\bgh\s+pr\s+create\b/;
+const GH_ISSUE_CREATE_RE = /\bgh\s+issue\s+create\b/;
 
 function parseSessionMessages(sessionPath: string): {
   exchanges: number;
   reworkInstances: number;
+  outcomes: number;
 } {
   let exchanges = 0;
   let reworkInstances = 0;
+  const editedFiles = new Set<string>();
+  let commits = 0;
+  let prs = 0;
+  let issues = 0;
 
   try {
     const content = readFileSync(sessionPath, "utf-8");
@@ -157,18 +181,37 @@ function parseSessionMessages(sessionPath: string): {
     for (const line of lines) {
       try {
         const msg: SessionMessage = JSON.parse(line);
-        if (msg.type !== "user") continue;
 
-        // Extract text content
-        const text = extractText(msg);
-        if (!text || text.trim().length === 0) continue;
-        if (isSystemMessage(text)) continue;
+        if (msg.type === "user") {
+          const text = extractText(msg);
+          if (!text || text.trim().length === 0) continue;
+          if (isSystemMessage(text)) continue;
 
-        exchanges++;
+          exchanges++;
 
-        // Check for rework language
-        if (REWORK_PATTERNS.some(p => p.test(text))) {
-          reworkInstances++;
+          if (REWORK_PATTERNS.some(p => p.test(text))) {
+            reworkInstances++;
+          }
+        } else if (msg.type === "assistant") {
+          // Count tool_use blocks as outcomes
+          const blocks = msg.message?.content;
+          if (!Array.isArray(blocks)) continue;
+
+          for (const block of blocks) {
+            if (block?.type !== "tool_use") continue;
+            const name: string = block.name || "";
+            const input: Record<string, unknown> = block.input || {};
+
+            if (name === "Write" || name === "Edit") {
+              const fp = input.file_path;
+              if (typeof fp === "string") editedFiles.add(fp);
+            } else if (name === "Bash") {
+              const cmd = typeof input.command === "string" ? input.command : "";
+              if (GIT_COMMIT_RE.test(cmd)) commits++;
+              if (GH_PR_CREATE_RE.test(cmd)) prs++;
+              if (GH_ISSUE_CREATE_RE.test(cmd)) issues++;
+            }
+          }
         }
       } catch {
         // skip malformed lines
@@ -178,7 +221,8 @@ function parseSessionMessages(sessionPath: string): {
     // session file unreadable
   }
 
-  return { exchanges, reworkInstances };
+  const outcomes = editedFiles.size + commits + prs + issues;
+  return { exchanges, reworkInstances, outcomes };
 }
 
 function extractText(msg: SessionMessage): string {

--- a/src/extractors/decision-quality.test.ts
+++ b/src/extractors/decision-quality.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
-import { extractDecisionQuality } from "./decision-quality.js";
+import { extractDecisionQuality, scoreCommitMessages } from "./decision-quality.js";
 
 describe("extractDecisionQuality", () => {
   it("returns empty signal for non-git directory", () => {
@@ -9,5 +9,63 @@ describe("extractDecisionQuality", () => {
     assert.equal(result.commitsWithWhy, 0);
     assert.equal(result.commitsWithIssueRef, 0);
     assert.deepEqual(result.commitMessages, []);
+  });
+});
+
+describe("scoreCommitMessages", () => {
+  it("counts explicit why-language", () => {
+    const result = scoreCommitMessages([
+      "refactor auth because the old middleware was non-compliant",
+      "update readme",
+    ]);
+    assert.equal(result.commitsWithWhy, 1);
+  });
+
+  it("counts conventional commit prefixes as why", () => {
+    const result = scoreCommitMessages([
+      "feat: add login form",
+      "fix: prevent null pointer in auth",
+      "refactor: extract validation logic",
+      "docs: update API reference",
+      "test: add coverage for edge cases",
+      "chore: bump dependencies",
+    ]);
+    assert.equal(result.commitsWithWhy, 6);
+  });
+
+  it("counts issue references as why", () => {
+    const result = scoreCommitMessages([
+      "update auth handling (#42)",
+      "improve performance for #15",
+    ]);
+    assert.equal(result.commitsWithWhy, 2);
+  });
+
+  it("does not double-count commits matching multiple signals", () => {
+    const result = scoreCommitMessages([
+      "fix: resolve null pointer because of missing check (#42)",
+    ]);
+    // One commit, should count as 1
+    assert.equal(result.commitsTotal, 1);
+    assert.equal(result.commitsWithWhy, 1);
+  });
+
+  it("does not count bare messages without why signals", () => {
+    const result = scoreCommitMessages([
+      "update stuff",
+      "changes",
+      "wip",
+    ]);
+    assert.equal(result.commitsWithWhy, 0);
+  });
+
+  it("still tracks issue refs separately", () => {
+    const result = scoreCommitMessages([
+      "feat: add login (#10)",
+      "fix something because reasons",
+      "update readme",
+    ]);
+    assert.equal(result.commitsWithIssueRef, 1);
+    assert.equal(result.commitsWithWhy, 2); // feat: and because
   });
 });

--- a/src/extractors/decision-quality.ts
+++ b/src/extractors/decision-quality.ts
@@ -14,10 +14,20 @@ export function extractDecisionQuality(
   since?: string
 ): DecisionQualitySignal {
   const commitMessages = getRecentCommits(projectDir, since);
+  return scoreCommitMessages(commitMessages);
+}
+
+/**
+ * Score commit messages for decision quality signals.
+ * Exported for testing — called by extractDecisionQuality with git-derived messages.
+ */
+export function scoreCommitMessages(commitMessages: string[]): DecisionQualitySignal {
   const commitsTotal = commitMessages.length;
 
   const commitsWithWhy = commitMessages.filter(msg =>
-    WHY_PATTERNS.some(p => p.test(msg))
+    WHY_PATTERNS.some(p => p.test(msg)) ||
+    CONVENTIONAL_PREFIX_RE.test(msg) ||
+    ISSUE_REF_RE.test(msg)
   ).length;
 
   const commitsWithIssueRef = commitMessages.filter(msg =>
@@ -28,11 +38,12 @@ export function extractDecisionQuality(
     commitsTotal,
     commitsWithWhy,
     commitsWithIssueRef,
-    externalContextProvided: false, // determined by session analysis, not git
+    externalContextProvided: false,
     commitMessages,
   };
 }
 
+/** Explicit why-language patterns */
 const WHY_PATTERNS = [
   /\bbecause\b/i,
   /\bso that\b/i,
@@ -51,6 +62,9 @@ const WHY_PATTERNS = [
   /\bfixes\b/i,
   /\bresolves\b/i,
 ];
+
+/** Conventional commit prefixes convey intent implicitly */
+const CONVENTIONAL_PREFIX_RE = /^(feat|fix|refactor|docs|test|chore|perf|ci|build|style|revert)(\(.+?\))?:/i;
 
 const ISSUE_REF_RE = /#\d+/;
 


### PR DESCRIPTION
## Summary
- **#26 (P1)** Outcome counter now parses session JSONL tool_use blocks (Write, Edit, Bash with git commit/gh pr create/gh issue create) instead of always returning 1
- **#27 (P3)** Rework detection expanded with 7 new patterns: `actually`, `try again`, `wait`, `hold on`, `never mind`, `scratch that`, `not correct`
- **#28 (P5)** Decision quality `commitsWithWhy` now includes conventional commit prefixes (`feat:`, `fix:`, etc.) and issue references (`#N`)

## Test Plan
- [x] 13 new tests added (88 total), all passing
- [x] Build clean (`tsc` exits 0)
- [ ] Verify against real session data after merge

Closes #26, closes #27, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)