### PR TITLE
fix: route leading flags to implicit run command (#31)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,9 @@ import { runSessions } from "./commands/sessions.js";
 import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
-const command = args[0] || "run";
+// Treat leading flags (--session, --json, etc.) as implicit "run" command
+const isImplicitRun = args[0]?.startsWith("--") && !["--help", "-h", "--version", "-v"].includes(args[0]);
+const command = isImplicitRun ? "run" : (args[0] || "run");
 
 function main(): void {
   switch (command) {
@@ -47,7 +49,7 @@ function main(): void {
 }
 
 async function run(): Promise<void> {
-  const runArgs = args.slice(1);
+  const runArgs = isImplicitRun ? args : args.slice(1);
   const sessionPath = flagValue(runArgs, "--session");
   const projectDir = resolve(
     runArgs.find((a) => !a.startsWith("--") && a !== sessionPath) ||


### PR DESCRIPTION
## Summary
- `pulse --session <path>` was hitting "Unknown command" because `args[0]` started with `--`
- Now flags that aren't `--help`/`--version` are treated as implicit `run` command
- Fixes routing so `pulse --session`, `pulse --json`, `pulse --no-save` all work without explicit `run`

## Test plan
- [x] `pulse --session /path/to.jsonl` routes to run
- [x] `pulse --help` still shows help
- [x] `pulse --version` still shows version
- [x] All 162 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)