### PR TITLE
fix: expand rework patterns and deduplicate outcomes by issue ref (#30)

### DIFF
--- a/src/commands/pulse.test.ts
+++ b/src/commands/pulse.test.ts
@@ -12,7 +12,7 @@ function makeReport(overrides: Record<string, unknown> = {}): Record<string, unk
     timestamp: "2026-03-27T10:00:00.000Z",
     project: "test",
     cwd: "/tmp/test",
-    convergence: { exchanges: 5, outcomes: 3, rate: 1.67, reworkInstances: 1, reworkPercent: 20 },
+    convergence: { exchanges: 5, outcomes: 3, rate: 1.67, reworkInstances: 1, reworkPercent: 20, duplicateCommits: 0 },
     intentAnchoring: { intentsPresent: false, claudeMdPresent: false, declaredIntents: [], relevantIntents: [], referencedIntents: [], gap: [], intentLayerCheck: null },
     decisionQuality: { commitsTotal: 3, commitsWithWhy: 1, commitsWithIssueRef: 0, externalContextProvided: false, commitMessages: [] },
     tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, tokensPerExchange: 0, tokensPerOutcome: 0, available: false },

--- a/src/extractors/convergence.test.ts
+++ b/src/extractors/convergence.test.ts
@@ -213,4 +213,134 @@ describe("rework detection", () => {
     const result = extractConvergence(session, 1);
     assert.equal(result.reworkInstances, 0);
   });
+
+  it("detects 'not fixed' and 'didn't fix' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "Not fixed even after I restart" },
+      { type: "user", content: "that didn't fix the issue" },
+      { type: "user", content: "this doesn't fix anything" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 3);
+  });
+
+  it("detects 'still *ing' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "still expanding vertically as it loads" },
+      { type: "user", content: "still failing on the same test" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("detects 'got worse' and 'getting worse' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "it got worse after that change" },
+      { type: "user", content: "the performance is getting worse" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("detects 'didn't work' and 'doesn't work' and 'not working' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "that didn't work at all" },
+      { type: "user", content: "this doesn't work either" },
+      { type: "user", content: "it's not working" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 3);
+  });
+
+  it("detects 'same issue/problem/error/bug' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "same issue as before" },
+      { type: "user", content: "same problem, nothing changed" },
+      { type: "user", content: "same error in the logs" },
+      { type: "user", content: "same bug, it's back" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 4);
+  });
+
+  it("detects 'no change' and 'no difference' as rework", () => {
+    const session = createSessionFile([
+      { type: "user", content: "no change from the last attempt" },
+      { type: "user", content: "no difference after applying the fix" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.reworkInstances, 2);
+  });
+
+  it("does not false-positive 'still' in normal context", () => {
+    const session = createSessionFile([
+      { type: "user", content: "I still need to add the tests" },
+      { type: "user", content: "we still want this feature" },
+    ]);
+    const result = extractConvergence(session, 1);
+    // "still need" and "still want" don't match /\bstill\s+\w+ing\b/
+    assert.equal(result.reworkInstances, 0);
+  });
+});
+
+describe("duplicate commit deduplication", () => {
+  it("deduplicates commits with the same issue ref", () => {
+    const session = createRawSessionFile([
+      userMsg("fix the bug"),
+      toolUseMsg("Bash", { command: 'git commit -m "fix(#93): make bars thicker"' }),
+      toolUseMsg("Bash", { command: 'git commit -m "fix(#93): actually make bars thicker"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 1);
+    assert.equal(result.duplicateCommits, 1);
+  });
+
+  it("counts commits with different issue refs as separate outcomes", () => {
+    const session = createRawSessionFile([
+      userMsg("fix bugs"),
+      toolUseMsg("Bash", { command: 'git commit -m "fix(#93): bars"' }),
+      toolUseMsg("Bash", { command: 'git commit -m "fix(#94): colors"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+    assert.equal(result.duplicateCommits, 0);
+  });
+
+  it("counts commits without issue refs individually", () => {
+    const session = createRawSessionFile([
+      userMsg("do stuff"),
+      toolUseMsg("Bash", { command: 'git commit -m "fix something"' }),
+      toolUseMsg("Bash", { command: 'git commit -m "fix something else"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+    assert.equal(result.duplicateCommits, 0);
+  });
+
+  it("counts mixed ref and no-ref commits correctly", () => {
+    const session = createRawSessionFile([
+      userMsg("fix"),
+      toolUseMsg("Bash", { command: 'git commit -m "fix(#93): first"' }),
+      toolUseMsg("Bash", { command: 'git commit -m "unrelated change"' }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+    assert.equal(result.duplicateCommits, 0);
+  });
+
+  it("handles single-quoted commit messages", () => {
+    const session = createRawSessionFile([
+      userMsg("fix"),
+      toolUseMsg("Bash", { command: "git commit -m 'fix(#93): first'" }),
+      toolUseMsg("Bash", { command: "git commit -m 'fix(#93): second'" }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 1);
+    assert.equal(result.duplicateCommits, 1);
+  });
+
+  it("returns duplicateCommits 0 when no session file", () => {
+    const result = extractConvergence(null, 5);
+    assert.equal(result.duplicateCommits, 0);
+  });
 });

--- a/src/extractors/convergence.ts
+++ b/src/extractors/convergence.ts
@@ -34,12 +34,14 @@ export function extractConvergence(
   let exchanges = 0;
   let reworkInstances = 0;
   let sessionOutcomes = 0;
+  let duplicateCommits = 0;
 
   if (sessionPath) {
     const parsed = parseSessionMessages(sessionPath);
     exchanges = parsed.exchanges;
     reworkInstances = parsed.reworkInstances;
     sessionOutcomes = parsed.outcomes;
+    duplicateCommits = parsed.duplicateCommits;
   }
 
   // Outcomes: max of session-derived outcomes and git filesChanged. Floor at 1 to avoid division by zero.
@@ -47,7 +49,7 @@ export function extractConvergence(
   const rate = exchanges > 0 ? round(exchanges / outcomes, 2) : 0;
   const reworkPercent = exchanges > 0 ? round((reworkInstances / exchanges) * 100, 1) : 0;
 
-  return { exchanges, outcomes, rate, reworkInstances, reworkPercent };
+  return { exchanges, outcomes, rate, reworkInstances, reworkPercent, duplicateCommits };
 }
 
 /**
@@ -156,21 +158,39 @@ const REWORK_PATTERNS = [
   /\bhold on\b/i,
   /\bnever mind\b/i,
   /\bscratch that\b/i,
+  /\bnot\s+fixed\b/i,
+  /\bdidn'?t\s+fix/i,
+  /\bdoesn'?t\s+fix/i,
+  /\bstill\s+\w+ing\b/i,
+  /\bgot\s+worse\b/i,
+  /\bgetting\s+worse\b/i,
+  /\bdidn'?t\s+work/i,
+  /\bdoesn'?t\s+work/i,
+  /\bnot\s+working\b/i,
+  /\bsame\s+(issue|problem|error|bug)\b/i,
+  /\bno\s+(change|difference)\b/i,
 ];
 
 const GIT_COMMIT_RE = /\bgit\s+commit\b/;
 const GH_PR_CREATE_RE = /\bgh\s+pr\s+create\b/;
 const GH_ISSUE_CREATE_RE = /\bgh\s+issue\s+create\b/;
 
+/** Extract issue refs (#N) from a git commit command's -m message */
+const COMMIT_MSG_RE = /-m\s+(?:"([^"]*?)"|'([^']*?)')/;
+const ISSUE_REF_RE = /#(\d+)/g;
+
 function parseSessionMessages(sessionPath: string): {
   exchanges: number;
   reworkInstances: number;
   outcomes: number;
+  duplicateCommits: number;
 } {
   let exchanges = 0;
   let reworkInstances = 0;
   const editedFiles = new Set<string>();
   let commits = 0;
+  let duplicateCommits = 0;
+  const seenIssueRefs = new Set<string>();
   let prs = 0;
   let issues = 0;
 
@@ -207,7 +227,31 @@ function parseSessionMessages(sessionPath: string): {
               if (typeof fp === "string") editedFiles.add(fp);
             } else if (name === "Bash") {
               const cmd = typeof input.command === "string" ? input.command : "";
-              if (GIT_COMMIT_RE.test(cmd)) commits++;
+              if (GIT_COMMIT_RE.test(cmd)) {
+                // Deduplicate commits by issue ref
+                const msgMatch = cmd.match(COMMIT_MSG_RE);
+                const commitMsg = msgMatch ? (msgMatch[1] ?? msgMatch[2] ?? "") : "";
+                const refs: string[] = [];
+                let refMatch: RegExpExecArray | null;
+                const issueRe = new RegExp(ISSUE_REF_RE.source, "g");
+                while ((refMatch = issueRe.exec(commitMsg)) !== null) {
+                  refs.push(refMatch[1]);
+                }
+
+                if (refs.length > 0) {
+                  // Check if any issue ref has been seen before
+                  const allSeen = refs.every(r => seenIssueRefs.has(r));
+                  if (allSeen) {
+                    duplicateCommits++;
+                  } else {
+                    commits++;
+                    for (const r of refs) seenIssueRefs.add(r);
+                  }
+                } else {
+                  // No issue ref — count as unique outcome
+                  commits++;
+                }
+              }
               if (GH_PR_CREATE_RE.test(cmd)) prs++;
               if (GH_ISSUE_CREATE_RE.test(cmd)) issues++;
             }
@@ -222,7 +266,7 @@ function parseSessionMessages(sessionPath: string): {
   }
 
   const outcomes = editedFiles.size + commits + prs + issues;
-  return { exchanges, reworkInstances, outcomes };
+  return { exchanges, reworkInstances, outcomes, duplicateCommits };
 }
 
 function extractText(msg: SessionMessage): string {

--- a/src/types/pulse.ts
+++ b/src/types/pulse.ts
@@ -37,6 +37,8 @@ export interface ConvergenceSignal {
   reworkInstances: number;
   /** reworkInstances / exchanges as percentage */
   reworkPercent: number;
+  /** Commits referencing the same issue as a prior commit (not counted as outcomes) */
+  duplicateCommits: number;
 }
 
 export interface IntentAnchoringSignal {


### PR DESCRIPTION
## Summary
- Rework patterns expanded from 19 to 30 — catches "not fixed", "got worse", "still *ing", "didn't work", "same issue/problem", "no change", etc.
- Commits referencing the same issue number (`#N`) are now deduplicated: repeated `fix(#93):` commits count as 1 outcome + N duplicates, not N outcomes
- Added `duplicateCommits` field to `ConvergenceSignal` type
- Tasks 1-2 of #30 — fixes two bugs that caused deceptively good metrics on a confirmed bad session

Known gap: "still + present-tense verb" (`still expands`) not yet covered — follow-up.

## Test plan
- [x] Each new rework pattern matches its target phrase (7 new test cases)
- [x] False positive guard: "still need to add" does NOT trigger rework
- [x] Duplicate commits with same issue ref → 1 outcome + duplicateCommits count
- [x] Different issue refs → separate outcomes
- [x] No-ref commits → count individually (unchanged behavior)
- [x] All 175 tests pass (162 existing + 13 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)