### PR TITLE
feat: continuous leverage score and baseline comparison command (#41, #42)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { runActivity } from "./commands/activity.js";
 import { runHistory } from "./commands/history.js";
 import { runTrend } from "./commands/trend.js";
 import { runSessions } from "./commands/sessions.js";
+import { runCompare } from "./commands/compare.js";
 import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -30,6 +31,9 @@ function main(): void {
       break;
     case "sessions":
       console.log(runSessions(args.slice(1)));
+      break;
+    case "compare":
+      console.log(runCompare(args.slice(1)));
       break;
     case "help":
     case "--help":
@@ -130,6 +134,7 @@ Usage:
   pulse activity <sub>   Session activity queries (sessions, summary, gc)
   pulse history [path]   Show saved pulse report history
   pulse trend [path]     Show metric trends over time
+  pulse compare          Compare metrics across time or projects
   pulse help             Show this help
   pulse version          Show version
 
@@ -147,6 +152,11 @@ Flags (history/trend):
   --range <N>d|h|m       Filter to reports within time range (e.g. 7d, 24h)
   --json                 Output as JSON array
   --metric <name>        Trend only: convergence, prompt, rework, leverage
+
+Flags (compare):
+  --before <date>        Split reports at date (e.g. 2026-03-15)
+  --json                 Output as JSON
+  (or: pulse compare /path/a /path/b for cross-project comparison)
 
 Run "pulse activity" for activity subcommand help.
 `.trim());

--- a/src/commands/compare.test.ts
+++ b/src/commands/compare.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  compareDateSplit,
+  compareCrossProject,
+  formatComparison,
+  runCompare,
+  CompareResult,
+} from "./compare.js";
+
+const tmpA = join(tmpdir(), "pulse-compare-a-" + process.pid);
+const tmpB = join(tmpdir(), "pulse-compare-b-" + process.pid);
+
+function makeReport(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timestamp: "2026-03-27T10:00:00.000Z",
+    project: "test",
+    cwd: "/tmp/test",
+    convergence: { exchanges: 5, outcomes: 3, rate: 1.67, reworkInstances: 1, reworkPercent: 20, duplicateCommits: 0 },
+    intentAnchoring: { intentsPresent: false, claudeMdPresent: false, declaredIntents: [], relevantIntents: [], referencedIntents: [], gap: [], intentLayerCheck: null },
+    decisionQuality: { commitsTotal: 3, commitsWithWhy: 1, commitsWithIssueRef: 0, externalContextProvided: false, commitMessages: [] },
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, tokensPerExchange: 0, tokensPerOutcome: 0, available: false },
+    interactionPattern: { userStyle: "directive", contextProvision: "structured", observation: "" },
+    promptEffectiveness: { available: true, events: [], scores: { contextProvision: 0.5, scopeDiscipline: 0.6, feedbackQuality: 0.4, decomposition: 0.7, verification: 0.8 }, overallScore: 0.6, rating: "good", observation: "", coaching: [] },
+    interactionLeverage: "MEDIUM",
+    leverageScore: 0.55,
+    ...overrides,
+  };
+}
+
+describe("compareDateSplit", () => {
+  beforeEach(() => mkdirSync(join(tmpA, ".pulse"), { recursive: true }));
+  afterEach(() => rmSync(tmpA, { recursive: true, force: true }));
+
+  it("splits reports at given date and computes deltas", () => {
+    const before1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z", convergence: { exchanges: 8, outcomes: 2, rate: 4.0, reworkInstances: 3, reworkPercent: 25, duplicateCommits: 0 }, leverageScore: 0.35 });
+    const before2 = makeReport({ timestamp: "2026-03-12T10:00:00.000Z", convergence: { exchanges: 6, outcomes: 3, rate: 2.0, reworkInstances: 2, reworkPercent: 15, duplicateCommits: 0 }, leverageScore: 0.45 });
+    const after1 = makeReport({ timestamp: "2026-03-16T10:00:00.000Z", convergence: { exchanges: 3, outcomes: 3, rate: 1.0, reworkInstances: 0, reworkPercent: 5, duplicateCommits: 0 }, leverageScore: 0.72 });
+    const after2 = makeReport({ timestamp: "2026-03-18T10:00:00.000Z", convergence: { exchanges: 2, outcomes: 2, rate: 1.0, reworkInstances: 0, reworkPercent: 3, duplicateCommits: 0 }, leverageScore: 0.80 });
+
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(before1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(before2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(after1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-4.json"), JSON.stringify(after2));
+
+    const result = compareDateSplit(tmpA, "2026-03-15");
+    assert.ok(typeof result !== "string", `expected CompareResult, got: ${result}`);
+    assert.equal(result.mode, "date-split");
+    assert.equal(result.leftCount, 2);
+    assert.equal(result.rightCount, 2);
+
+    const conv = result.metrics.find((m) => m.metric === "Convergence Rate")!;
+    assert.equal(conv.left, 3.0); // avg of 4.0 and 2.0
+    assert.equal(conv.right, 1.0); // avg of 1.0 and 1.0
+    assert.equal(conv.direction, "improved"); // lower is better
+
+    const leverage = result.metrics.find((m) => m.metric === "Leverage Score")!;
+    assert.equal(leverage.left, 0.4); // avg of 0.35 and 0.45
+    assert.equal(leverage.right, 0.76); // avg of 0.72 and 0.80
+    assert.equal(leverage.direction, "improved"); // higher is better
+  });
+
+  it("returns error for invalid date", () => {
+    const result = compareDateSplit(tmpA, "not-a-date");
+    assert.ok(typeof result === "string");
+    assert.ok(result.includes("Invalid date"));
+  });
+
+  it("returns error when no reports exist", () => {
+    const empty = join(tmpdir(), "pulse-compare-empty-" + process.pid);
+    const result = compareDateSplit(empty, "2026-03-15");
+    assert.ok(typeof result === "string");
+    assert.ok(result.includes("No pulse reports"));
+  });
+
+  it("returns error when fewer than 2 reports before date", () => {
+    const r1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z" });
+    const r2 = makeReport({ timestamp: "2026-03-20T10:00:00.000Z" });
+    const r3 = makeReport({ timestamp: "2026-03-22T10:00:00.000Z" });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(r1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(r2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(r3));
+
+    const result = compareDateSplit(tmpA, "2026-03-15");
+    assert.ok(typeof result === "string");
+    assert.ok(result.includes("Need at least 2 reports before"));
+  });
+
+  it("returns error when fewer than 2 reports after date", () => {
+    const r1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z" });
+    const r2 = makeReport({ timestamp: "2026-03-12T10:00:00.000Z" });
+    const r3 = makeReport({ timestamp: "2026-03-20T10:00:00.000Z" });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(r1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(r2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(r3));
+
+    const result = compareDateSplit(tmpA, "2026-03-15");
+    assert.ok(typeof result === "string");
+    assert.ok(result.includes("Need at least 2 reports after"));
+  });
+});
+
+describe("compareCrossProject", () => {
+  beforeEach(() => {
+    mkdirSync(join(tmpA, ".pulse"), { recursive: true });
+    mkdirSync(join(tmpB, ".pulse"), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(tmpA, { recursive: true, force: true });
+    rmSync(tmpB, { recursive: true, force: true });
+  });
+
+  it("compares two projects", () => {
+    const a1 = makeReport({ timestamp: "2026-03-26T10:00:00.000Z", convergence: { exchanges: 8, outcomes: 2, rate: 4.0, reworkInstances: 3, reworkPercent: 20, duplicateCommits: 0 }, leverageScore: 0.35 });
+    const a2 = makeReport({ timestamp: "2026-03-27T10:00:00.000Z", convergence: { exchanges: 6, outcomes: 3, rate: 3.0, reworkInstances: 2, reworkPercent: 15, duplicateCommits: 0 }, leverageScore: 0.45 });
+    const b1 = makeReport({ timestamp: "2026-03-26T10:00:00.000Z", convergence: { exchanges: 3, outcomes: 3, rate: 1.0, reworkInstances: 0, reworkPercent: 5, duplicateCommits: 0 }, leverageScore: 0.72 });
+    const b2 = makeReport({ timestamp: "2026-03-27T10:00:00.000Z", convergence: { exchanges: 2, outcomes: 2, rate: 1.0, reworkInstances: 0, reworkPercent: 3, duplicateCommits: 0 }, leverageScore: 0.80 });
+
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(a1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(a2));
+    writeFileSync(join(tmpB, ".pulse", "pulse-1.json"), JSON.stringify(b1));
+    writeFileSync(join(tmpB, ".pulse", "pulse-2.json"), JSON.stringify(b2));
+
+    const result = compareCrossProject(tmpA, tmpB);
+    assert.ok(typeof result !== "string", `expected CompareResult, got: ${result}`);
+    assert.equal(result.mode, "cross-project");
+    assert.equal(result.leftCount, 2);
+    assert.equal(result.rightCount, 2);
+
+    const conv = result.metrics.find((m) => m.metric === "Convergence Rate")!;
+    assert.equal(conv.left, 3.5); // avg of 4.0 and 3.0
+    assert.equal(conv.right, 1.0);
+    assert.equal(conv.direction, "improved");
+  });
+
+  it("returns error when project A has too few reports", () => {
+    const a1 = makeReport({ timestamp: "2026-03-27T10:00:00.000Z" });
+    const b1 = makeReport({ timestamp: "2026-03-26T10:00:00.000Z" });
+    const b2 = makeReport({ timestamp: "2026-03-27T10:00:00.000Z" });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(a1));
+    writeFileSync(join(tmpB, ".pulse", "pulse-1.json"), JSON.stringify(b1));
+    writeFileSync(join(tmpB, ".pulse", "pulse-2.json"), JSON.stringify(b2));
+
+    const result = compareCrossProject(tmpA, tmpB);
+    assert.ok(typeof result === "string");
+    assert.ok(result.includes("Need at least 2 reports"));
+  });
+});
+
+describe("formatComparison", () => {
+  it("formats date-split comparison with direction labels", () => {
+    const result: CompareResult = {
+      mode: "date-split",
+      leftLabel: "before 2026-03-15",
+      rightLabel: "after 2026-03-15",
+      leftCount: 3,
+      rightCount: 4,
+      metrics: [
+        { metric: "Convergence Rate", left: 3.20, right: 1.80, delta: -1.40, direction: "improved", lowerIsBetter: true },
+        { metric: "Rework %", left: 18, right: 8, delta: -10, direction: "improved", lowerIsBetter: true },
+        { metric: "Leverage Score", left: 0.45, right: 0.72, delta: 0.27, direction: "improved", lowerIsBetter: false },
+        { metric: "Prompt Score", left: 0.55, right: 0.70, delta: 0.15, direction: "improved", lowerIsBetter: false },
+      ],
+    };
+
+    const output = formatComparison(result);
+    assert.ok(output.includes("before 2026-03-15 vs after 2026-03-15"));
+    assert.ok(output.includes("Before"));
+    assert.ok(output.includes("After"));
+    assert.ok(output.includes("Convergence Rate"));
+    assert.ok(output.includes("improved"));
+    assert.ok(output.includes("3 vs 4"));
+  });
+
+  it("formats cross-project comparison with project labels", () => {
+    const result: CompareResult = {
+      mode: "cross-project",
+      leftLabel: "project-a",
+      rightLabel: "project-b",
+      leftCount: 5,
+      rightCount: 5,
+      metrics: [
+        { metric: "Convergence Rate", left: 2.0, right: 2.1, delta: 0.1, direction: "declined", lowerIsBetter: true },
+        { metric: "Rework %", left: 10, right: 10, delta: 0, direction: "stable", lowerIsBetter: true },
+        { metric: "Leverage Score", left: 0.60, right: 0.60, delta: 0, direction: "stable", lowerIsBetter: false },
+        { metric: "Prompt Score", left: null, right: 0.70, delta: null, direction: "n/a", lowerIsBetter: false },
+      ],
+    };
+
+    const output = formatComparison(result);
+    assert.ok(output.includes("project-a vs project-b"));
+    assert.ok(output.includes("project-a"));
+    assert.ok(output.includes("project-b"));
+    assert.ok(output.includes("stable"));
+    assert.ok(output.includes("n/a"));
+  });
+});
+
+describe("runCompare", () => {
+  beforeEach(() => mkdirSync(join(tmpA, ".pulse"), { recursive: true }));
+  afterEach(() => rmSync(tmpA, { recursive: true, force: true }));
+
+  it("shows usage when no flags or paths given", () => {
+    const output = runCompare([]);
+    assert.ok(output.includes("Usage"));
+  });
+
+  it("runs date-split mode with --before flag", () => {
+    const r1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z", leverageScore: 0.4 });
+    const r2 = makeReport({ timestamp: "2026-03-12T10:00:00.000Z", leverageScore: 0.5 });
+    const r3 = makeReport({ timestamp: "2026-03-20T10:00:00.000Z", leverageScore: 0.7 });
+    const r4 = makeReport({ timestamp: "2026-03-22T10:00:00.000Z", leverageScore: 0.8 });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(r1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(r2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(r3));
+    writeFileSync(join(tmpA, ".pulse", "pulse-4.json"), JSON.stringify(r4));
+
+    const output = runCompare(["--before", "2026-03-15", tmpA]);
+    assert.ok(output.includes("Pulse Comparison"));
+    assert.ok(output.includes("Convergence Rate"));
+  });
+
+  it("outputs JSON with --json flag in date-split mode", () => {
+    const r1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z" });
+    const r2 = makeReport({ timestamp: "2026-03-12T10:00:00.000Z" });
+    const r3 = makeReport({ timestamp: "2026-03-20T10:00:00.000Z" });
+    const r4 = makeReport({ timestamp: "2026-03-22T10:00:00.000Z" });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(r1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(r2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(r3));
+    writeFileSync(join(tmpA, ".pulse", "pulse-4.json"), JSON.stringify(r4));
+
+    const output = runCompare(["--before", "2026-03-15", "--json", tmpA]);
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.mode, "date-split");
+    assert.equal(parsed.metrics.length, 4);
+    assert.ok(parsed.metrics[0].delta !== undefined);
+  });
+
+  it("handles prompt score n/a when unavailable", () => {
+    const r1 = makeReport({ timestamp: "2026-03-10T10:00:00.000Z", promptEffectiveness: { available: false, events: [], scores: { contextProvision: 0, scopeDiscipline: 0, feedbackQuality: 0, decomposition: 0, verification: 0 }, overallScore: 0, rating: "developing", observation: "", coaching: [] } });
+    const r2 = makeReport({ timestamp: "2026-03-12T10:00:00.000Z", promptEffectiveness: { available: false, events: [], scores: { contextProvision: 0, scopeDiscipline: 0, feedbackQuality: 0, decomposition: 0, verification: 0 }, overallScore: 0, rating: "developing", observation: "", coaching: [] } });
+    const r3 = makeReport({ timestamp: "2026-03-20T10:00:00.000Z" });
+    const r4 = makeReport({ timestamp: "2026-03-22T10:00:00.000Z" });
+    writeFileSync(join(tmpA, ".pulse", "pulse-1.json"), JSON.stringify(r1));
+    writeFileSync(join(tmpA, ".pulse", "pulse-2.json"), JSON.stringify(r2));
+    writeFileSync(join(tmpA, ".pulse", "pulse-3.json"), JSON.stringify(r3));
+    writeFileSync(join(tmpA, ".pulse", "pulse-4.json"), JSON.stringify(r4));
+
+    const output = runCompare(["--before", "2026-03-15", "--json", tmpA]);
+    const parsed = JSON.parse(output);
+    const prompt = parsed.metrics.find((m: { metric: string }) => m.metric === "Prompt Score");
+    assert.equal(prompt.left, null);
+    assert.equal(prompt.direction, "n/a");
+  });
+});

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,0 +1,220 @@
+import { PulseReport } from "../types/pulse.js";
+import { loadReports } from "./history.js";
+import { basename, resolve } from "node:path";
+
+export interface CompareOptions {
+  before?: string;
+  json?: boolean;
+}
+
+export interface MetricComparison {
+  metric: string;
+  left: number | null;
+  right: number | null;
+  delta: number | null;
+  direction: "improved" | "declined" | "stable" | "n/a";
+  lowerIsBetter: boolean;
+}
+
+export interface CompareResult {
+  mode: "date-split" | "cross-project";
+  leftLabel: string;
+  rightLabel: string;
+  leftCount: number;
+  rightCount: number;
+  metrics: MetricComparison[];
+}
+
+function avgOrNull(values: (number | null)[]): number | null {
+  const nums = values.filter((v): v is number => v !== null);
+  if (nums.length === 0) return null;
+  return Math.round((nums.reduce((a, b) => a + b, 0) / nums.length) * 100) / 100;
+}
+
+function computeMetrics(reports: PulseReport[]): Record<string, number | null> {
+  return {
+    convergenceRate: avgOrNull(reports.map((r) => r.convergence.rate)),
+    reworkPercent: avgOrNull(reports.map((r) => r.convergence.reworkPercent)),
+    leverageScore: avgOrNull(
+      reports.map((r) =>
+        r.leverageScore !== undefined
+          ? r.leverageScore
+          : r.interactionLeverage === "HIGH" ? 0.85 : r.interactionLeverage === "MEDIUM" ? 0.55 : 0.2
+      )
+    ),
+    promptScore: avgOrNull(
+      reports.map((r) => (r.promptEffectiveness.available ? r.promptEffectiveness.overallScore : null))
+    ),
+  };
+}
+
+function compareMetric(
+  name: string,
+  left: number | null,
+  right: number | null,
+  lowerIsBetter: boolean
+): MetricComparison {
+  if (left === null || right === null) {
+    return { metric: name, left, right, delta: null, direction: "n/a", lowerIsBetter };
+  }
+  const delta = Math.round((right - left) * 100) / 100;
+  const threshold = 0.01;
+  let direction: MetricComparison["direction"];
+  if (Math.abs(delta) < threshold) {
+    direction = "stable";
+  } else if (lowerIsBetter) {
+    direction = delta < 0 ? "improved" : "declined";
+  } else {
+    direction = delta > 0 ? "improved" : "declined";
+  }
+  return { metric: name, left, right, delta, direction, lowerIsBetter };
+}
+
+function buildComparison(
+  leftReports: PulseReport[],
+  rightReports: PulseReport[],
+  leftLabel: string,
+  rightLabel: string,
+  mode: CompareResult["mode"]
+): CompareResult {
+  const leftMetrics = computeMetrics(leftReports);
+  const rightMetrics = computeMetrics(rightReports);
+
+  const metrics: MetricComparison[] = [
+    compareMetric("Convergence Rate", leftMetrics.convergenceRate, rightMetrics.convergenceRate, true),
+    compareMetric("Rework %", leftMetrics.reworkPercent, rightMetrics.reworkPercent, true),
+    compareMetric("Leverage Score", leftMetrics.leverageScore, rightMetrics.leverageScore, false),
+    compareMetric("Prompt Score", leftMetrics.promptScore, rightMetrics.promptScore, false),
+  ];
+
+  return {
+    mode,
+    leftLabel,
+    rightLabel,
+    leftCount: leftReports.length,
+    rightCount: rightReports.length,
+    metrics,
+  };
+}
+
+export function compareDateSplit(projectDir: string, beforeDate: string): CompareResult | string {
+  const cutoff = new Date(beforeDate);
+  if (isNaN(cutoff.getTime())) {
+    return `Invalid date: ${beforeDate}. Use ISO format (e.g. 2026-03-15).`;
+  }
+
+  const all = loadReports(projectDir);
+  if (all.length === 0) {
+    return "No pulse reports found. Run `pulse` to generate reports.";
+  }
+
+  const before = all.filter((r) => new Date(r.timestamp) < cutoff);
+  const after = all.filter((r) => new Date(r.timestamp) >= cutoff);
+
+  if (before.length < 2) {
+    return `Need at least 2 reports before ${beforeDate} (found ${before.length}). Generate more reports first.`;
+  }
+  if (after.length < 2) {
+    return `Need at least 2 reports after ${beforeDate} (found ${after.length}). Generate more reports first.`;
+  }
+
+  return buildComparison(before, after, `before ${beforeDate}`, `after ${beforeDate}`, "date-split");
+}
+
+export function compareCrossProject(pathA: string, pathB: string): CompareResult | string {
+  const reportsA = loadReports(pathA);
+  const reportsB = loadReports(pathB);
+
+  if (reportsA.length < 2) {
+    return `Need at least 2 reports in ${pathA} (found ${reportsA.length}). Generate more reports first.`;
+  }
+  if (reportsB.length < 2) {
+    return `Need at least 2 reports in ${pathB} (found ${reportsB.length}). Generate more reports first.`;
+  }
+
+  const labelA = basename(pathA) || pathA;
+  const labelB = basename(pathB) || pathB;
+
+  return buildComparison(reportsA, reportsB, labelA, labelB, "cross-project");
+}
+
+function formatMetricValue(metric: string, value: number | null): string {
+  if (value === null) return "n/a";
+  if (metric === "Rework %") return `${value}%`;
+  return value.toFixed(2);
+}
+
+function formatDelta(metric: string, delta: number | null, direction: string): string {
+  if (delta === null) return "n/a";
+  const sign = delta > 0 ? "+" : "";
+  const suffix = metric === "Rework %" ? "%" : "";
+  return `${sign}${delta.toFixed(2)}${suffix} (${direction})`;
+}
+
+export function formatComparison(result: CompareResult): string {
+  const lines: string[] = [];
+  const header = result.mode === "date-split"
+    ? `Pulse Comparison (${result.leftLabel} vs ${result.rightLabel})`
+    : `Pulse Comparison (${result.leftLabel} vs ${result.rightLabel})`;
+
+  lines.push(header);
+  lines.push("─".repeat(60));
+  lines.push(`Reports: ${result.leftCount} vs ${result.rightCount}`);
+  lines.push("");
+
+  const col1 = 22;
+  const col2 = 10;
+  const col3 = 10;
+
+  const leftHeader = result.mode === "date-split" ? "Before" : result.leftLabel;
+  const rightHeader = result.mode === "date-split" ? "After" : result.rightLabel;
+
+  lines.push(
+    "".padEnd(col1) +
+    leftHeader.padStart(col2) +
+    rightHeader.padStart(col2) +
+    "Delta".padStart(col2 + 14)
+  );
+
+  for (const m of result.metrics) {
+    const left = formatMetricValue(m.metric, m.left).padStart(col2);
+    const right = formatMetricValue(m.metric, m.right).padStart(col3);
+    const delta = formatDelta(m.metric, m.delta, m.direction);
+    lines.push(`${m.metric.padEnd(col1)}${left}${right}     ${delta}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function runCompare(argv: string[]): string {
+  const jsonFlag = argv.includes("--json");
+  const beforeIdx = argv.indexOf("--before");
+  const beforeDate = beforeIdx !== -1 && beforeIdx + 1 < argv.length ? argv[beforeIdx + 1] : undefined;
+
+  // Collect positional args (not flags or flag values)
+  const skipNext = new Set<number>();
+  if (beforeIdx !== -1) { skipNext.add(beforeIdx); skipNext.add(beforeIdx + 1); }
+  const jsonIdx = argv.indexOf("--json");
+  if (jsonIdx !== -1) skipNext.add(jsonIdx);
+
+  const positional = argv.filter((a, i) => !skipNext.has(i) && !a.startsWith("--"));
+
+  if (beforeDate) {
+    // Date-split mode
+    const projectDir = resolve(positional[0] || process.cwd());
+    const result = compareDateSplit(projectDir, beforeDate);
+    if (typeof result === "string") return result;
+    return jsonFlag ? JSON.stringify(result, null, 2) : formatComparison(result);
+  }
+
+  if (positional.length >= 2) {
+    // Cross-project mode
+    const pathA = resolve(positional[0]);
+    const pathB = resolve(positional[1]);
+    const result = compareCrossProject(pathA, pathB);
+    if (typeof result === "string") return result;
+    return jsonFlag ? JSON.stringify(result, null, 2) : formatComparison(result);
+  }
+
+  return "Usage: pulse compare --before <date> [path]  or  pulse compare /path/a /path/b\n\nOptions:\n  --before <date>  Split reports at date (ISO format)\n  --json           Output as JSON";
+}

--- a/src/commands/history.test.ts
+++ b/src/commands/history.test.ts
@@ -19,6 +19,7 @@ function makeReport(overrides: Record<string, unknown> = {}): Record<string, unk
     interactionPattern: { userStyle: "directive", contextProvision: "structured", observation: "" },
     promptEffectiveness: { available: false, events: [], scores: { contextProvision: 0, scopeDiscipline: 0, feedbackQuality: 0, decomposition: 0, verification: 0 }, overallScore: 0, rating: "developing", observation: "" },
     interactionLeverage: "MEDIUM",
+    leverageScore: 0.55,
     ...overrides,
   };
 }

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -44,7 +44,9 @@ function summarize(report: PulseReport): ReportSummary {
     date: report.timestamp.slice(0, 10),
     convergenceRate: report.convergence.rate,
     promptScore: report.promptEffectiveness.available ? report.promptEffectiveness.overallScore : null,
-    leverage: report.interactionLeverage,
+    leverage: report.leverageScore !== undefined
+      ? `${report.leverageScore.toFixed(2)} (${report.interactionLeverage})`
+      : report.interactionLeverage,
     outcomes: report.convergence.outcomes,
   };
 }

--- a/src/commands/pulse.test.ts
+++ b/src/commands/pulse.test.ts
@@ -3,7 +3,7 @@ import * as assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadHistoricalScores, formatDelta, runPulse } from "./pulse.js";
+import { loadHistoricalScores, formatDelta, runPulse, computeLeverage } from "./pulse.js";
 
 const tmp = join(tmpdir(), "pulse-coaching-test-" + process.pid);
 
@@ -27,9 +27,59 @@ function makeReport(overrides: Record<string, unknown> = {}): Record<string, unk
       coaching: [],
     },
     interactionLeverage: "MEDIUM",
+    leverageScore: 0.55,
     ...overrides,
   };
 }
+
+describe("computeLeverage", () => {
+  it("returns HIGH score for perfect session", () => {
+    const convergence = { exchanges: 3, outcomes: 3, rate: 1.0, reworkInstances: 0, reworkPercent: 0, duplicateCommits: 0 };
+    const dq = { commitsTotal: 3, commitsWithWhy: 3, commitsWithIssueRef: 3, externalContextProvided: false, commitMessages: [] };
+    const { score, label } = computeLeverage(convergence, dq);
+    assert.ok(score >= 0.7, `expected HIGH, got score ${score}`);
+    assert.equal(label, "HIGH");
+  });
+
+  it("returns LOW score for poor session", () => {
+    const convergence = { exchanges: 20, outcomes: 2, rate: 10.0, reworkInstances: 5, reworkPercent: 25, duplicateCommits: 0 };
+    const dq = { commitsTotal: 2, commitsWithWhy: 0, commitsWithIssueRef: 0, externalContextProvided: false, commitMessages: [] };
+    const { score, label } = computeLeverage(convergence, dq);
+    assert.ok(score < 0.4, `expected LOW, got score ${score}`);
+    assert.equal(label, "LOW");
+  });
+
+  it("returns MEDIUM score for average session", () => {
+    const convergence = { exchanges: 6, outcomes: 3, rate: 2.0, reworkInstances: 1, reworkPercent: 10, duplicateCommits: 0 };
+    const dq = { commitsTotal: 3, commitsWithWhy: 2, commitsWithIssueRef: 1, externalContextProvided: false, commitMessages: [] };
+    const { score, label } = computeLeverage(convergence, dq);
+    assert.ok(score >= 0.4 && score < 0.7, `expected MEDIUM, got score ${score}`);
+    assert.equal(label, "MEDIUM");
+  });
+
+  it("score is always between 0 and 1", () => {
+    // Edge case: extreme values
+    const convergence = { exchanges: 100, outcomes: 1, rate: 100, reworkInstances: 100, reworkPercent: 100, duplicateCommits: 0 };
+    const dq = { commitsTotal: 0, commitsWithWhy: 0, commitsWithIssueRef: 0, externalContextProvided: false, commitMessages: [] };
+    const { score } = computeLeverage(convergence, dq);
+    assert.ok(score >= 0, `score should be >= 0, got ${score}`);
+    assert.ok(score <= 1, `score should be <= 1, got ${score}`);
+  });
+
+  it("handles zero commits gracefully", () => {
+    const convergence = { exchanges: 3, outcomes: 1, rate: 3.0, reworkInstances: 0, reworkPercent: 0, duplicateCommits: 0 };
+    const dq = { commitsTotal: 0, commitsWithWhy: 0, commitsWithIssueRef: 0, externalContextProvided: false, commitMessages: [] };
+    const { score } = computeLeverage(convergence, dq);
+    assert.ok(score >= 0 && score <= 1);
+  });
+
+  it("handles zero rate (no exchanges or perfect ratio)", () => {
+    const convergence = { exchanges: 0, outcomes: 0, rate: 0, reworkInstances: 0, reworkPercent: 0, duplicateCommits: 0 };
+    const dq = { commitsTotal: 5, commitsWithWhy: 5, commitsWithIssueRef: 5, externalContextProvided: false, commitMessages: [] };
+    const { score } = computeLeverage(convergence, dq);
+    assert.ok(score >= 0.7, `expected HIGH for perfect outcome quality + zero rate, got ${score}`);
+  });
+});
 
 describe("loadHistoricalScores", () => {
   beforeEach(() => mkdirSync(join(tmp, ".pulse"), { recursive: true }));

--- a/src/commands/pulse.ts
+++ b/src/commands/pulse.ts
@@ -21,7 +21,7 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
   const tokenUsage = extractTokenUsage(sessionFile, convergence.exchanges, convergence.outcomes);
   const interactionPattern = extractInteractionPattern(sessionFile);
   const promptEffectiveness = await extractPromptEffectiveness(sessionFile);
-  const interactionLeverage = computeLeverage(convergence, decisionQuality);
+  const { score: leverageScore, label: interactionLeverage } = computeLeverage(convergence, decisionQuality);
 
   return {
     timestamp: new Date().toISOString(),
@@ -34,6 +34,7 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
     interactionPattern,
     promptEffectiveness,
     interactionLeverage,
+    leverageScore,
   };
 }
 
@@ -135,7 +136,7 @@ export function formatReport(report: PulseReport): string {
 
   // Summary
   lines.push(hr);
-  lines.push(`Interaction Leverage:    ${report.interactionLeverage}`);
+  lines.push(`Interaction Leverage:    ${report.leverageScore.toFixed(2)} (${report.interactionLeverage})`);
   lines.push(hr);
 
   // Actionable nudges
@@ -185,17 +186,32 @@ function countFilesChanged(projectDir: string, timeWindow: SessionTimeWindow): n
   }
 }
 
-function computeLeverage(
+export function computeLeverage(
   convergence: PulseReport["convergence"],
   decisionQuality: PulseReport["decisionQuality"]
-): "HIGH" | "MEDIUM" | "LOW" {
+): { score: number; label: "HIGH" | "MEDIUM" | "LOW" } {
   const { rate, reworkPercent } = convergence;
+  const { commitsTotal, commitsWithWhy, commitsWithIssueRef } = decisionQuality;
 
-  // HIGH: <=1 exchange per outcome, <10% rework
-  if (rate <= 1 && reworkPercent < 10) return "HIGH";
-  // LOW: >4 exchanges per outcome or >15% rework
-  if (rate > 4 || reworkPercent > 15) return "LOW";
-  return "MEDIUM";
+  // Outcome Quality: commit message quality (why + issue refs)
+  const outcomeQuality = commitsTotal > 0
+    ? (commitsWithWhy / commitsTotal) * 0.5 + (commitsWithIssueRef / commitsTotal) * 0.5
+    : 0;
+
+  // Efficiency: inverse of convergence rate (lower rate = higher efficiency)
+  const efficiency = 1 / (1 + rate);
+
+  // Stability: inverse of rework percentage
+  const stability = 1 - (reworkPercent / 100);
+
+  // Equal weight blend, clamped to [0, 1]
+  const raw = (outcomeQuality + efficiency + stability) / 3;
+  const score = Math.round(Math.max(0, Math.min(1, raw)) * 100) / 100;
+
+  // Derive label from score thresholds
+  const label: "HIGH" | "MEDIUM" | "LOW" = score >= 0.7 ? "HIGH" : score >= 0.4 ? "MEDIUM" : "LOW";
+
+  return { score, label };
 }
 
 function rateLabel(rate: number): string {

--- a/src/commands/trend.test.ts
+++ b/src/commands/trend.test.ts
@@ -20,6 +20,7 @@ function makeReport(overrides: Record<string, unknown> = {}): Record<string, unk
     interactionPattern: { userStyle: "directive", contextProvision: "structured", observation: "" },
     promptEffectiveness: { available: false, events: [], scores: { contextProvision: 0, scopeDiscipline: 0, feedbackQuality: 0, decomposition: 0, verification: 0 }, overallScore: 0, rating: "developing", observation: "" },
     interactionLeverage: "MEDIUM",
+    leverageScore: 0.55,
     ...overrides,
   };
 }
@@ -55,8 +56,8 @@ describe("sparkline", () => {
 describe("extractTrends", () => {
   it("extracts all four metric trends", () => {
     const reports = [
-      makeReport({ timestamp: "2026-03-27T10:00:00.000Z", convergence: { exchanges: 5, outcomes: 3, rate: 2.0, reworkInstances: 1, reworkPercent: 10 }, interactionLeverage: "MEDIUM" }),
-      makeReport({ timestamp: "2026-03-26T10:00:00.000Z", convergence: { exchanges: 3, outcomes: 3, rate: 1.0, reworkInstances: 0, reworkPercent: 5 }, interactionLeverage: "HIGH" }),
+      makeReport({ timestamp: "2026-03-27T10:00:00.000Z", convergence: { exchanges: 5, outcomes: 3, rate: 2.0, reworkInstances: 1, reworkPercent: 10 }, interactionLeverage: "MEDIUM", leverageScore: 0.55 }),
+      makeReport({ timestamp: "2026-03-26T10:00:00.000Z", convergence: { exchanges: 3, outcomes: 3, rate: 1.0, reworkInstances: 0, reworkPercent: 5 }, interactionLeverage: "HIGH", leverageScore: 0.82 }),
     ] as unknown as PulseReport[];
 
     const trends = extractTrends(reports);

--- a/src/commands/trend.ts
+++ b/src/commands/trend.ts
@@ -78,7 +78,7 @@ export function extractTrends(reports: PulseReport[]): TrendData[] {
 
   const leverageValues = chrono.map((r) => ({
     date: r.timestamp.slice(0, 10),
-    value: r.interactionLeverage === "HIGH" ? 3 : r.interactionLeverage === "MEDIUM" ? 2 : 1,
+    value: r.leverageScore ?? (r.interactionLeverage === "HIGH" ? 0.85 : r.interactionLeverage === "MEDIUM" ? 0.55 : 0.2),
   }));
   const leverageNums = leverageValues.map((v) => v.value);
 
@@ -142,7 +142,7 @@ function lastNullable(values: (number | null)[]): number | null {
 function formatValue(metric: string, value: number | null): string {
   if (value === null) return "n/a";
   if (metric === "rework") return `${value}%`;
-  if (metric === "leverage") return value === 3 ? "HIGH" : value === 2 ? "MEDIUM" : "LOW";
+  if (metric === "leverage") return value.toFixed(2);
   return value.toFixed(2);
 }
 
@@ -161,9 +161,7 @@ export function formatTrend(trends: TrendData[], reportCount: number, rangeLabel
 
   for (const t of trends) {
     const label = (labels[t.metric] ?? t.metric).padEnd(20);
-    const spark = t.metric === "leverage"
-      ? t.values.map((v) => v.value === 3 ? "HIGH" : v.value === 2 ? "MED" : "LOW").join(" ")
-      : sparkline(t.values.map((v) => v.value), t.hint === "lower is better");
+    const spark = sparkline(t.values.map((v) => v.value), t.hint === "lower is better");
     const first = t.values.length > 0 ? formatValue(t.metric, t.values[0].value) : "n/a";
     const last = formatValue(t.metric, t.current);
     lines.push(`${label}${spark}   ${first} → ${last}  (${t.hint})`);

--- a/src/types/pulse.ts
+++ b/src/types/pulse.ts
@@ -9,6 +9,7 @@ export interface PulseReport {
   interactionPattern: InteractionPatternSignal;
   promptEffectiveness: PromptEffectivenessSignal;
   interactionLeverage: "HIGH" | "MEDIUM" | "LOW";
+  leverageScore: number;
 }
 
 export interface TokenUsageSignal {


### PR DESCRIPTION
## Summary
- **#41 — Continuous Leverage Score:** Added `leverageScore` (0.0–1.0) to `PulseReport`, computed from outcome quality, efficiency (inverse convergence rate), and stability (inverse rework %). Existing `HIGH`/`MEDIUM`/`LOW` labels derived from score thresholds (≥0.7, ≥0.4, <0.4). Trend sparkline now uses the continuous value.
- **#42 — Baseline Comparison:** Added `pulse compare` command with two modes: `--before <date>` for before/after date splits, and positional paths for cross-project comparison. Shows delta with direction labels (improved/declined/stable). Includes `--json` flag and minimum-2-reports-per-side validation.

Closes #41
Closes #42

## Test plan
- [x] 6 new `computeLeverage` tests: HIGH/MEDIUM/LOW thresholds, bounds clamping, zero commits, zero rate
- [x] 13 new `compare` tests: date-split mode, cross-project mode, formatting, JSON output, error cases, n/a handling
- [x] All 196 tests pass (183 existing + 13 new compare + 6 new leverage = 196 → 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)