### PR TITLE
feat: support new MPG session event fields (#50)

### DIFF
--- a/src/activity/mpg-correlator.test.ts
+++ b/src/activity/mpg-correlator.test.ts
@@ -93,4 +93,28 @@ describe("correlateMpgEvents", () => {
     const result = correlateMpgEvents("/path/to/session.jsonl", undefined, "/nonexistent/mpg-sessions.jsonl");
     assert.equal(result, null);
   });
+
+  it("includes events from the same thread_id across different session IDs", () => {
+    const events: MpgSessionEvent[] = [
+      { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "session_start", session_id: "my-session", project_key: "t", project_dir: "/t", thread_id: "thread-1" },
+      { schema_version: 1, timestamp: "2026-03-30T10:01:00Z", event_type: "agent_handoff", session_id: "my-session", project_key: "t", project_dir: "/t", thread_id: "thread-1", from_agent: "pm", to_agent: "engineer" },
+      { schema_version: 1, timestamp: "2026-03-30T10:02:00Z", event_type: "session_start", session_id: "other-session", project_key: "t", project_dir: "/t", thread_id: "thread-1", agent_name: "engineer" },
+      { schema_version: 1, timestamp: "2026-03-30T10:03:00Z", event_type: "message_routed", session_id: "other-session", project_key: "t", project_dir: "/t", thread_id: "thread-1", agent_target: "engineer" },
+      { schema_version: 1, timestamp: "2026-03-30T10:04:00Z", event_type: "session_start", session_id: "unrelated", project_key: "t", project_dir: "/t", thread_id: "thread-2" },
+    ];
+    const result = correlateMpgEvents("/path/to/my-session.jsonl", events);
+    assert.notEqual(result, null);
+    assert.equal(result!.sessionId, "my-session");
+    assert.equal(result!.events.length, 4); // all thread-1 events, not the unrelated one
+  });
+
+  it("does not expand correlation when no thread_id is present", () => {
+    const events: MpgSessionEvent[] = [
+      { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "session_start", session_id: "my-session", project_key: "t", project_dir: "/t" },
+      { schema_version: 1, timestamp: "2026-03-30T10:01:00Z", event_type: "message_routed", session_id: "other-session", project_key: "t", project_dir: "/t" },
+    ];
+    const result = correlateMpgEvents("/path/to/my-session.jsonl", events);
+    assert.notEqual(result, null);
+    assert.equal(result!.events.length, 1);
+  });
 });

--- a/src/activity/mpg-correlator.ts
+++ b/src/activity/mpg-correlator.ts
@@ -49,7 +49,8 @@ export function sessionIdFromPath(sessionPath: string): string {
 
 /**
  * Correlate MPG events with a Claude Code session.
- * Matches by session_id = filename (minus .jsonl extension).
+ * First matches by session_id, then expands to include all events
+ * sharing the same thread_id (handoffs may span multiple session IDs).
  * Returns null if no MPG events match this session.
  */
 export function correlateMpgEvents(
@@ -63,7 +64,25 @@ export function correlateMpgEvents(
   if (events.length === 0) return null;
 
   const sessionId = sessionIdFromPath(sessionPath);
-  const matched = events.filter(e => e.session_id === sessionId);
+
+  // Find events directly matching this session
+  const directMatches = events.filter(e => e.session_id === sessionId);
+
+  // Collect thread_ids from direct matches to pull in related events
+  const threadIds = new Set<string>();
+  for (const e of directMatches) {
+    if (e.thread_id) threadIds.add(e.thread_id);
+  }
+
+  // If we have thread_ids, include all events from those threads
+  let matched: MpgSessionEvent[];
+  if (threadIds.size > 0) {
+    matched = events.filter(
+      e => e.session_id === sessionId || (e.thread_id != null && threadIds.has(e.thread_id))
+    );
+  } else {
+    matched = directMatches;
+  }
 
   if (matched.length === 0) return null;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,8 @@ import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 // Treat leading flags (--session, --json, etc.) as implicit "run" command
-const isImplicitRun = args[0]?.startsWith("--") && !["--help", "-h", "--version", "-v"].includes(args[0]);
+const knownCommands = new Set(["run", "activity", "history", "trend", "sessions", "compare", "anonymize", "help", "version", "--help", "-h", "--version", "-v"]);
+const isImplicitRun = args[0] != null && !knownCommands.has(args[0]);
 const command = isImplicitRun ? "run" : (args[0] || "run");
 
 function main(): void {

--- a/src/extractors/convergence.test.ts
+++ b/src/extractors/convergence.test.ts
@@ -436,4 +436,16 @@ describe("MPG enrichment — per-agent convergence", () => {
     const breakdown = computeAgentBreakdown(mpgData);
     assert.equal(breakdown[0].agent, "reviewer");
   });
+
+  it("falls back to agent_name from session_start when agent_target and persona are absent", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test-session",
+      events: [
+        { schema_version: 1, timestamp: "2026-03-30T09:59:00Z", event_type: "session_start", session_id: "test-session", project_key: "test", project_dir: "/test", agent_name: "architect" },
+        makeMpgEvent({ agent_target: undefined, persona: undefined }),
+      ],
+    };
+    const breakdown = computeAgentBreakdown(mpgData);
+    assert.equal(breakdown[0].agent, "architect");
+  });
 });

--- a/src/extractors/convergence.ts
+++ b/src/extractors/convergence.ts
@@ -73,11 +73,19 @@ export function extractConvergence(
  * and computes a convergence penalty based on error rate.
  */
 export function computeAgentBreakdown(mpgData: CorrelatedMpgData): AgentConvergenceStats[] {
+  // Build session_id → agent_name lookup from session_start events
+  const sessionAgentMap = new Map<string, string>();
+  for (const event of mpgData.events) {
+    if (event.event_type === "session_start" && event.agent_name) {
+      sessionAgentMap.set(event.session_id, event.agent_name);
+    }
+  }
+
   const agentMap = new Map<string, { messages: number; errors: number }>();
 
   for (const event of mpgData.events) {
     if (event.event_type !== "message_routed") continue;
-    const agent = event.agent_target || event.persona || "unknown";
+    const agent = event.agent_target || event.persona || sessionAgentMap.get(event.session_id) || "unknown";
     const entry = agentMap.get(agent) || { messages: 0, errors: 0 };
     entry.messages++;
     if (event.is_error) entry.errors++;

--- a/src/extractors/interaction-pattern.test.ts
+++ b/src/extractors/interaction-pattern.test.ts
@@ -162,9 +162,9 @@ describe("interaction-pattern extractor", () => {
     const mpgData: CorrelatedMpgData = {
       sessionId: "test",
       events: [
-        { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", agent_source: "pm", agent_target: "engineer" },
-        { schema_version: 1, timestamp: "2026-03-30T10:01:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", agent_source: "engineer", agent_target: "qa" },
-        { schema_version: 1, timestamp: "2026-03-30T10:02:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", agent_source: "pm", agent_target: "engineer" },
+        { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", from_agent: "pm", to_agent: "engineer" },
+        { schema_version: 1, timestamp: "2026-03-30T10:01:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", from_agent: "engineer", to_agent: "qa" },
+        { schema_version: 1, timestamp: "2026-03-30T10:02:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", from_agent: "pm", to_agent: "engineer" },
       ],
     };
     const result = extractInteractionPattern(session, mpgData);
@@ -188,8 +188,8 @@ describe("handoff pattern classification", () => {
       session_id: "test",
       project_key: "t",
       project_dir: "/t",
-      agent_source: from,
-      agent_target: to,
+      from_agent: from,
+      to_agent: to,
     };
   }
 
@@ -220,6 +220,35 @@ describe("handoff pattern classification", () => {
     const result = computeHandoffPatterns(mpgData);
     assert.ok(result);
     assert.equal(result!.pattern, "iterative");
+  });
+
+  it("handles user-initiated handoffs (missing from_agent)", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test",
+      events: [
+        { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", to_agent: "engineer" },
+        makeHandoff("engineer", "qa"),
+      ],
+    };
+    const result = computeHandoffPatterns(mpgData);
+    assert.ok(result);
+    assert.equal(result!.totalHandoffs, 2);
+    const userToEng = result!.handoffPairs.find(p => p.from === "user" && p.to === "engineer");
+    assert.ok(userToEng);
+    assert.equal(userToEng!.count, 1);
+  });
+
+  it("falls back to legacy agent_source/agent_target fields", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test",
+      events: [
+        { schema_version: 1, timestamp: "2026-03-30T10:00:00Z", event_type: "agent_handoff", session_id: "test", project_key: "t", project_dir: "/t", agent_source: "pm", agent_target: "engineer" },
+      ],
+    };
+    const result = computeHandoffPatterns(mpgData);
+    assert.ok(result);
+    assert.equal(result!.handoffPairs[0].from, "pm");
+    assert.equal(result!.handoffPairs[0].to, "engineer");
   });
 
   it("returns null when no handoff events exist", () => {

--- a/src/extractors/interaction-pattern.ts
+++ b/src/extractors/interaction-pattern.ts
@@ -109,11 +109,11 @@ export function computeHandoffPatterns(mpgData: CorrelatedMpgData): HandoffPatte
   const handoffEvents = mpgData.events.filter(e => e.event_type === "agent_handoff");
   if (handoffEvents.length === 0) return null;
 
-  // Count handoff pairs
+  // Count handoff pairs (prefer new from_agent/to_agent fields, fall back to legacy)
   const pairCounts = new Map<string, { from: string; to: string; count: number }>();
   for (const event of handoffEvents) {
-    const from = event.agent_source || "unknown";
-    const to = event.agent_target || "unknown";
+    const from = event.from_agent || event.agent_source || "user";
+    const to = event.to_agent || event.agent_target || "unknown";
     const key = `${from}→${to}`;
     const existing = pairCounts.get(key);
     if (existing) {

--- a/src/types/pulse.ts
+++ b/src/types/pulse.ts
@@ -208,8 +208,12 @@ export interface MpgSessionEvent {
   session_id: string;
   project_key: string;
   project_dir: string;
+  /** Thread ID for correlating handoffs across sessions */
+  thread_id?: string;
   /** Only on session_end */
   duration_ms?: number;
+  /** Agent name, present on session_start */
+  agent_name?: string;
   /** Only on message_routed */
   persona?: string;
   /** Target agent for routed messages or handoffs */
@@ -220,6 +224,10 @@ export interface MpgSessionEvent {
   error_type?: string;
   /** Source agent for agent_handoff events */
   agent_source?: string;
+  /** Source agent for agent_handoff events (new MPG field) */
+  from_agent?: string;
+  /** Target agent for agent_handoff events (new MPG field) */
+  to_agent?: string;
   /** How the message was routed (e.g. "direct", "round-robin", "capability") */
   routing_method?: string;
 }


### PR DESCRIPTION
## Summary
- **thread_id correlation**: Handoff events and target agent sessions may have different session IDs — correlator now expands matches via `thread_id` to capture the full thread
- **agent_name resolution**: `session_start` events carry `agent_name`, used as fallback when `message_routed` lacks `agent_target`/`persona`
- **from_agent/to_agent**: Handoff extractor prefers new fields, falls back to legacy `agent_source`/`agent_target`; missing `from_agent` defaults to `"user"` for user-initiated handoffs
- **CLI fix**: `pulse /path/to/project` no longer errors as "Unknown command"

Closes #50
Depends on yama-kei/multi-project-gateway#169

## Test plan
- [x] 258/258 tests pass (5 new tests added)
- [ ] Run `pulse ~/Documents/multi-project-gateway` after an MPG session with new event format
- [ ] Verify per-agent breakdown shows named agents instead of `unknown`
- [ ] Verify handoff patterns appear with `from_agent`/`to_agent` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)