### PR TITLE
feat: decision event detection + session economics (#55)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-session-economics.md
+++ b/docs/superpowers/plans/2026-04-08-session-economics.md
@@ -1,0 +1,1163 @@
+# Session Economics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add time-awareness and economic scoring (Session ROI) to pulse reports, measuring decision yield against token/time cost.
+
+**Architecture:** New extractor `session-economics.ts` computes time analysis (duration, active/idle, thrashing) and dollar cost. ROI composite computed in `pulse.ts` alongside existing `computeLeverage()`. Each extractor stays focused; orchestrator composes.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, zero dependencies.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/types/pulse.ts` | Modify | Add `SessionEconomicsSignal`, `ThrashingEpisode`, `ModelPricing` types; extend `PulseReport` |
+| `src/extractors/session-economics.ts` | Create | Time analysis, thrashing detection, dollar cost calculation |
+| `src/extractors/session-economics.test.ts` | Create | Tests for all extractor logic |
+| `src/commands/pulse.ts` | Modify | Add `computeSessionROI()`, wire extractor in `runPulse()`, format report section, update `aggregateReports()` |
+| `src/commands/pulse.test.ts` | Modify | Add ROI scoring tests |
+
+---
+
+### Task 1: Add types to pulse.ts
+
+**Files:**
+- Modify: `src/types/pulse.ts`
+
+- [ ] **Step 1: Add SessionEconomicsSignal, ThrashingEpisode, and ModelPricing types**
+
+Add after the `DecisionQualitySignal` interface (after line 212):
+
+```typescript
+export interface SessionEconomicsSignal {
+  /** Wall-clock duration from first to last message (ms) */
+  durationMs: number;
+  /** Time spent with active exchanges — messages < 5min apart (ms) */
+  activeMs: number;
+  /** Estimated idle time — sum of gaps > 5min (ms) */
+  idleMs: number;
+  /** Number of idle gaps detected */
+  idleGaps: number;
+  /** Thrashing episodes: stretches of 4+ exchanges with no decision events */
+  thrashingEpisodes: ThrashingEpisode[];
+  /** Token cost in dollars (null if model pricing unavailable) */
+  costDollars: number | null;
+  /** Tokens spent per decision event */
+  tokensPerDecision: number;
+  /** Tokens estimated burned during thrashing episodes */
+  thrashingTokens: number;
+}
+
+export interface ThrashingEpisode {
+  /** Exchange range start (inclusive, 0-based) */
+  startExchange: number;
+  /** Exchange range end (inclusive, 0-based) */
+  endExchange: number;
+  /** Number of exchanges in this episode */
+  exchanges: number;
+  /** Estimated tokens consumed — proportional allocation */
+  estimatedTokens: number;
+}
+
+export interface ModelPricing {
+  /** Dollars per million input tokens */
+  inputPerMTok: number;
+  /** Dollars per million output tokens */
+  outputPerMTok: number;
+}
+```
+
+- [ ] **Step 2: Extend PulseReport interface**
+
+Add three new fields to the `PulseReport` interface:
+
+```typescript
+export interface PulseReport {
+  // ... existing fields ...
+  interactionLeverage: "HIGH" | "MEDIUM" | "LOW";
+  leverageScore: number;
+  sessionEconomics: SessionEconomicsSignal;
+  sessionROI: number;
+  sessionROILabel: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE";
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: Type errors in `pulse.ts` because `runPulse()` and `aggregateReports()` don't return the new fields yet. This is expected — we'll fix them in later tasks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/pulse.ts
+git commit -m "feat(types): add SessionEconomicsSignal and extend PulseReport (#55)"
+```
+
+---
+
+### Task 2: Create session-economics extractor — time analysis
+
+**Files:**
+- Create: `src/extractors/session-economics.ts`
+- Create: `src/extractors/session-economics.test.ts`
+
+- [ ] **Step 1: Write failing tests for time analysis**
+
+Create `src/extractors/session-economics.test.ts`:
+
+```typescript
+import { describe, it, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import { extractSessionEconomics } from "./session-economics.js";
+import { TokenUsageSignal, ConvergenceSignal } from "../types/pulse.js";
+import { writeFileSync, mkdtempSync, unlinkSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpFiles: string[] = [];
+let tmpDirs: string[] = [];
+
+function createSessionFile(entries: Array<{ type: string; timestamp: string; model?: string; input_tokens?: number; output_tokens?: number }>): string {
+  const dir = mkdtempSync(join(tmpdir(), "pulse-econ-test-"));
+  tmpDirs.push(dir);
+  const filePath = join(dir, "session.jsonl");
+  const lines = entries.map(e => {
+    const obj: any = { type: e.type, timestamp: e.timestamp };
+    if (e.type === "user") {
+      obj.message = { role: "user", content: "test message" };
+    } else {
+      obj.message = { role: "assistant", content: "response" };
+      if (e.model) obj.message.model = e.model;
+      if (e.input_tokens !== undefined || e.output_tokens !== undefined) {
+        obj.message.usage = {
+          input_tokens: e.input_tokens ?? 0,
+          output_tokens: e.output_tokens ?? 0,
+        };
+      }
+    }
+    return JSON.stringify(obj);
+  });
+  writeFileSync(filePath, lines.join("\n") + "\n");
+  tmpFiles.push(filePath);
+  return filePath;
+}
+
+function makeTokenUsage(overrides?: Partial<TokenUsageSignal>): TokenUsageSignal {
+  return {
+    inputTokens: 10000,
+    outputTokens: 5000,
+    totalTokens: 15000,
+    tokensPerExchange: 3000,
+    tokensPerOutcome: 5000,
+    available: true,
+    ...overrides,
+  };
+}
+
+function makeConvergence(overrides?: Partial<ConvergenceSignal>): ConvergenceSignal {
+  return {
+    exchanges: 5,
+    outcomes: 3,
+    rate: 1.67,
+    reworkInstances: 0,
+    reworkPercent: 0,
+    duplicateCommits: 0,
+    blindRetries: 0,
+    pivot: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const f of tmpFiles) { try { unlinkSync(f); } catch {} }
+  for (const d of tmpDirs) { try { rmdirSync(d); } catch {} }
+  tmpFiles = [];
+  tmpDirs = [];
+});
+
+describe("extractSessionEconomics — time analysis", () => {
+  it("computes duration from first to last timestamp", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:10:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:11:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(session, makeTokenUsage(), makeConvergence({ exchanges: 2 }));
+    assert.equal(result.durationMs, 11 * 60 * 1000); // 11 minutes
+  });
+
+  it("detects idle gaps > 5 minutes", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+      // 10 minute gap (idle)
+      { type: "user", timestamp: "2026-04-08T10:11:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:12:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(session, makeTokenUsage(), makeConvergence({ exchanges: 2 }));
+    assert.equal(result.idleGaps, 1);
+    assert.equal(result.idleMs, 10 * 60 * 1000); // 10 minutes idle
+    assert.equal(result.activeMs, 2 * 60 * 1000); // 2 minutes active
+  });
+
+  it("does not flag gaps <= 5 minutes as idle", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:04:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:05:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(session, makeTokenUsage(), makeConvergence({ exchanges: 2 }));
+    assert.equal(result.idleGaps, 0);
+    assert.equal(result.idleMs, 0);
+  });
+
+  it("returns zero duration for null session path", () => {
+    const result = extractSessionEconomics(null, makeTokenUsage(), makeConvergence());
+    assert.equal(result.durationMs, 0);
+    assert.equal(result.activeMs, 0);
+    assert.equal(result.idleMs, 0);
+  });
+
+  it("handles single-message session", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(session, makeTokenUsage(), makeConvergence({ exchanges: 1 }));
+    assert.equal(result.durationMs, 0);
+    assert.equal(result.idleMs, 0);
+    assert.equal(result.activeMs, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: FAIL — `session-economics.js` does not exist yet.
+
+- [ ] **Step 3: Implement time analysis in session-economics.ts**
+
+Create `src/extractors/session-economics.ts`:
+
+```typescript
+import { SessionEconomicsSignal, ThrashingEpisode, TokenUsageSignal, ConvergenceSignal, ModelPricing } from "../types/pulse.js";
+import { readFileSync } from "node:fs";
+
+const IDLE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Extract session economics signal: time analysis, thrashing detection, dollar cost.
+ */
+export function extractSessionEconomics(
+  sessionPath: string | null,
+  tokenUsage: TokenUsageSignal,
+  convergence: ConvergenceSignal
+): SessionEconomicsSignal {
+  const empty: SessionEconomicsSignal = {
+    durationMs: 0,
+    activeMs: 0,
+    idleMs: 0,
+    idleGaps: 0,
+    thrashingEpisodes: [],
+    costDollars: null,
+    tokensPerDecision: Infinity,
+    thrashingTokens: 0,
+  };
+
+  if (!sessionPath) return empty;
+
+  const timestamps = readTimestamps(sessionPath);
+  const { durationMs, activeMs, idleMs, idleGaps } = analyzeTime(timestamps);
+  const thrashingEpisodes = detectThrashing(convergence, tokenUsage);
+  const thrashingTokens = thrashingEpisodes.reduce((s, e) => s + e.estimatedTokens, 0);
+  const costDollars = computeCost(sessionPath, tokenUsage);
+  const decisionCount = convergence.decisionEvents?.length ?? 0;
+  const tokensPerDecision = decisionCount > 0 ? Math.round(tokenUsage.totalTokens / decisionCount) : Infinity;
+
+  return {
+    durationMs,
+    activeMs,
+    idleMs,
+    idleGaps,
+    thrashingEpisodes,
+    costDollars,
+    tokensPerDecision,
+    thrashingTokens,
+  };
+}
+
+function readTimestamps(sessionPath: string): number[] {
+  const timestamps: number[] = [];
+  try {
+    const content = readFileSync(sessionPath, "utf-8");
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.timestamp) {
+          timestamps.push(new Date(msg.timestamp).getTime());
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+  } catch {
+    // unreadable
+  }
+  return timestamps;
+}
+
+function analyzeTime(timestamps: number[]): { durationMs: number; activeMs: number; idleMs: number; idleGaps: number } {
+  if (timestamps.length < 2) {
+    return { durationMs: 0, activeMs: 0, idleMs: 0, idleGaps: 0 };
+  }
+  const durationMs = timestamps[timestamps.length - 1] - timestamps[0];
+  let idleMs = 0;
+  let idleGaps = 0;
+
+  for (let i = 1; i < timestamps.length; i++) {
+    const gap = timestamps[i] - timestamps[i - 1];
+    if (gap > IDLE_THRESHOLD_MS) {
+      idleMs += gap;
+      idleGaps++;
+    }
+  }
+
+  const activeMs = durationMs - idleMs;
+  return { durationMs, activeMs, idleMs, idleGaps };
+}
+
+/** Placeholder — implemented in Task 3 */
+function detectThrashing(convergence: ConvergenceSignal, tokenUsage: TokenUsageSignal): ThrashingEpisode[] {
+  return [];
+}
+
+/** Placeholder — implemented in Task 4 */
+function computeCost(sessionPath: string, tokenUsage: TokenUsageSignal): number | null {
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: All 5 time analysis tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extractors/session-economics.ts src/extractors/session-economics.test.ts
+git commit -m "feat: add session-economics extractor with time analysis (#55)"
+```
+
+---
+
+### Task 3: Add thrashing detection
+
+**Files:**
+- Modify: `src/extractors/session-economics.ts`
+- Modify: `src/extractors/session-economics.test.ts`
+
+- [ ] **Step 1: Write failing tests for thrashing detection**
+
+Append to `session-economics.test.ts`:
+
+```typescript
+describe("extractSessionEconomics — thrashing detection", () => {
+  it("detects thrashing when 4+ exchanges have no decisions", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:00:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:01:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:02:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:02:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:03:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:03:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:04:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:04:30.000Z" },
+    ]);
+    // 5 exchanges, decisions only at exchange 0
+    const convergence = makeConvergence({
+      exchanges: 5,
+      decisionEvents: [{ atExchange: 0, type: "approved", detail: "yes" }],
+    });
+    const result = extractSessionEconomics(session, makeTokenUsage({ totalTokens: 50000 }), convergence);
+    assert.equal(result.thrashingEpisodes.length, 1);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 1);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+    assert.equal(result.thrashingEpisodes[0].exchanges, 4);
+    // 4/5 of total tokens = 40000
+    assert.equal(result.thrashingEpisodes[0].estimatedTokens, 40000);
+    assert.equal(result.thrashingTokens, 40000);
+  });
+
+  it("does not flag thrashing for sequences < 4 exchanges", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:00:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:01:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:30.000Z" },
+      { type: "user", timestamp: "2026-04-08T10:02:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:02:30.000Z" },
+    ]);
+    // 3 exchanges, decision at exchange 0
+    const convergence = makeConvergence({
+      exchanges: 3,
+      decisionEvents: [{ atExchange: 0, type: "approved", detail: "yes" }],
+    });
+    const result = extractSessionEconomics(session, makeTokenUsage(), convergence);
+    assert.equal(result.thrashingEpisodes.length, 0);
+  });
+
+  it("detects multiple thrashing episodes separated by decisions", () => {
+    const session = createSessionFile(
+      Array.from({ length: 20 }, (_, i) => [
+        { type: "user" as const, timestamp: `2026-04-08T10:${String(i).padStart(2, "0")}:00.000Z` },
+        { type: "assistant" as const, timestamp: `2026-04-08T10:${String(i).padStart(2, "0")}:30.000Z` },
+      ]).flat()
+    );
+    // 10 exchanges: decisions at 0 and 5 — gaps at 1-4 and 6-9
+    const convergence = makeConvergence({
+      exchanges: 10,
+      decisionEvents: [
+        { atExchange: 0, type: "approved", detail: "yes" },
+        { atExchange: 5, type: "delegated", detail: "go" },
+      ],
+    });
+    const result = extractSessionEconomics(session, makeTokenUsage({ totalTokens: 100000 }), convergence);
+    assert.equal(result.thrashingEpisodes.length, 2);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 1);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+    assert.equal(result.thrashingEpisodes[1].startExchange, 6);
+    assert.equal(result.thrashingEpisodes[1].endExchange, 9);
+  });
+
+  it("flags entire session as thrashing if 0 decisions and 4+ exchanges", () => {
+    const session = createSessionFile(
+      Array.from({ length: 10 }, (_, i) => [
+        { type: "user" as const, timestamp: `2026-04-08T10:${String(i).padStart(2, "0")}:00.000Z` },
+        { type: "assistant" as const, timestamp: `2026-04-08T10:${String(i).padStart(2, "0")}:30.000Z` },
+      ]).flat()
+    );
+    const convergence = makeConvergence({ exchanges: 5, decisionEvents: undefined });
+    const result = extractSessionEconomics(session, makeTokenUsage(), convergence);
+    assert.equal(result.thrashingEpisodes.length, 1);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 0);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+  });
+
+  it("no thrashing if 0 decisions and < 4 exchanges", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:00:30.000Z" },
+    ]);
+    const convergence = makeConvergence({ exchanges: 1, decisionEvents: undefined });
+    const result = extractSessionEconomics(session, makeTokenUsage(), convergence);
+    assert.equal(result.thrashingEpisodes.length, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: FAIL — thrashing tests fail because `detectThrashing` returns `[]`.
+
+- [ ] **Step 3: Implement detectThrashing**
+
+Replace the `detectThrashing` placeholder in `session-economics.ts`:
+
+```typescript
+function detectThrashing(convergence: ConvergenceSignal, tokenUsage: TokenUsageSignal): ThrashingEpisode[] {
+  const totalExchanges = convergence.exchanges;
+  if (totalExchanges < 4) return [];
+
+  const decisionIndices = new Set(
+    (convergence.decisionEvents ?? []).map(e => e.atExchange)
+  );
+
+  const episodes: ThrashingEpisode[] = [];
+  let runStart: number | null = null;
+
+  for (let i = 0; i < totalExchanges; i++) {
+    if (decisionIndices.has(i)) {
+      // End any open run
+      if (runStart !== null) {
+        const runLen = i - runStart;
+        if (runLen >= 4) {
+          episodes.push(makeEpisode(runStart, i - 1, runLen, totalExchanges, tokenUsage.totalTokens));
+        }
+      }
+      runStart = null;
+    } else {
+      if (runStart === null) runStart = i;
+    }
+  }
+
+  // Close trailing run
+  if (runStart !== null) {
+    const runLen = totalExchanges - runStart;
+    if (runLen >= 4) {
+      episodes.push(makeEpisode(runStart, totalExchanges - 1, runLen, totalExchanges, tokenUsage.totalTokens));
+    }
+  }
+
+  return episodes;
+}
+
+function makeEpisode(start: number, end: number, exchanges: number, totalExchanges: number, totalTokens: number): ThrashingEpisode {
+  return {
+    startExchange: start,
+    endExchange: end,
+    exchanges,
+    estimatedTokens: totalExchanges > 0 ? Math.round((exchanges / totalExchanges) * totalTokens) : 0,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: All time analysis + thrashing tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extractors/session-economics.ts src/extractors/session-economics.test.ts
+git commit -m "feat: add thrashing detection to session-economics extractor (#55)"
+```
+
+---
+
+### Task 4: Add dollar cost model
+
+**Files:**
+- Modify: `src/extractors/session-economics.ts`
+- Modify: `src/extractors/session-economics.test.ts`
+
+- [ ] **Step 1: Write failing tests for dollar cost**
+
+Append to `session-economics.test.ts`:
+
+```typescript
+describe("extractSessionEconomics — dollar cost", () => {
+  it("computes cost from model pricing in session JSONL", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z", model: "claude-opus-4-6", input_tokens: 1000, output_tokens: 500 },
+      { type: "user", timestamp: "2026-04-08T10:02:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:03:00.000Z", model: "claude-opus-4-6", input_tokens: 2000, output_tokens: 1000 },
+    ]);
+    const tu = makeTokenUsage({ inputTokens: 3000, outputTokens: 1500, totalTokens: 4500 });
+    const result = extractSessionEconomics(session, tu, makeConvergence({ exchanges: 2 }));
+    // opus: input=$15/MTok, output=$75/MTok
+    // cost = (3000 * 15 / 1_000_000) + (1500 * 75 / 1_000_000) = 0.045 + 0.1125 = 0.1575
+    assert.ok(result.costDollars !== null);
+    assert.equal(Math.round(result.costDollars! * 10000), Math.round(0.1575 * 10000));
+  });
+
+  it("returns null cost when no model field in session", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(session, makeTokenUsage(), makeConvergence({ exchanges: 1 }));
+    assert.equal(result.costDollars, null);
+  });
+
+  it("handles blended cost with multiple models", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z", model: "claude-opus-4-6", input_tokens: 1000, output_tokens: 500 },
+      { type: "user", timestamp: "2026-04-08T10:02:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:03:00.000Z", model: "claude-haiku-4-5", input_tokens: 2000, output_tokens: 1000 },
+    ]);
+    const tu = makeTokenUsage({ inputTokens: 3000, outputTokens: 1500, totalTokens: 4500 });
+    const result = extractSessionEconomics(session, tu, makeConvergence({ exchanges: 2 }));
+    // opus: (1000 * 15 + 500 * 75) / 1M = 0.015 + 0.0375 = 0.0525
+    // haiku: (2000 * 0.80 + 1000 * 4) / 1M = 0.0016 + 0.004 = 0.0056
+    // total: 0.0581
+    assert.ok(result.costDollars !== null);
+    assert.ok(result.costDollars! > 0.05 && result.costDollars! < 0.07);
+  });
+
+  it("uses prefix matching for model versions", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z", model: "claude-sonnet-4-6", input_tokens: 1000, output_tokens: 500 },
+    ]);
+    const tu = makeTokenUsage({ inputTokens: 1000, outputTokens: 500, totalTokens: 1500 });
+    const result = extractSessionEconomics(session, tu, makeConvergence({ exchanges: 1 }));
+    // sonnet: (1000 * 3 + 500 * 15) / 1M = 0.003 + 0.0075 = 0.0105
+    assert.ok(result.costDollars !== null);
+    assert.equal(Math.round(result.costDollars! * 10000), Math.round(0.0105 * 10000));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: FAIL — cost tests fail because `computeCost` returns `null`.
+
+- [ ] **Step 3: Implement computeCost with pricing table and model detection**
+
+Replace the `computeCost` placeholder in `session-economics.ts`:
+
+```typescript
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  "claude-opus-4": { inputPerMTok: 15, outputPerMTok: 75 },
+  "claude-sonnet-4": { inputPerMTok: 3, outputPerMTok: 15 },
+  "claude-haiku-4": { inputPerMTok: 0.80, outputPerMTok: 4 },
+};
+
+function computeCost(sessionPath: string, tokenUsage: TokenUsageSignal): number | null {
+  if (!tokenUsage.available) return null;
+
+  const perMessageCosts = readPerMessageCosts(sessionPath);
+  if (perMessageCosts === null) return null;
+
+  return Math.round(perMessageCosts * 10000) / 10000; // 4 decimal places
+}
+
+interface MessageTokens {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+function readPerMessageCosts(sessionPath: string): number | null {
+  const messages: MessageTokens[] = [];
+
+  try {
+    const content = readFileSync(sessionPath, "utf-8");
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.message?.role !== "assistant") continue;
+        const model = msg.message?.model;
+        if (!model) continue;
+        const usage = msg.message?.usage;
+        messages.push({
+          model,
+          inputTokens: usage?.input_tokens ?? 0,
+          outputTokens: usage?.output_tokens ?? 0,
+        });
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (messages.length === 0) return null;
+
+  let totalCost = 0;
+  for (const msg of messages) {
+    const pricing = findPricing(msg.model);
+    if (!pricing) continue;
+    totalCost += (msg.inputTokens * pricing.inputPerMTok / 1_000_000)
+              + (msg.outputTokens * pricing.outputPerMTok / 1_000_000);
+  }
+
+  return totalCost;
+}
+
+function findPricing(model: string): ModelPricing | null {
+  for (const [prefix, pricing] of Object.entries(MODEL_PRICING)) {
+    if (model.startsWith(prefix)) return pricing;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/extractors/session-economics.ts src/extractors/session-economics.test.ts
+git commit -m "feat: add dollar cost model to session-economics extractor (#55)"
+```
+
+---
+
+### Task 5: Add tokensPerDecision tests
+
+**Files:**
+- Modify: `src/extractors/session-economics.test.ts`
+
+- [ ] **Step 1: Write tests for tokensPerDecision**
+
+Append to `session-economics.test.ts`:
+
+```typescript
+describe("extractSessionEconomics — tokensPerDecision", () => {
+  it("computes tokens per decision from total tokens and decision count", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+    ]);
+    const convergence = makeConvergence({
+      exchanges: 5,
+      decisionEvents: [
+        { atExchange: 0, type: "approved", detail: "yes" },
+        { atExchange: 2, type: "delegated", detail: "go" },
+      ],
+    });
+    const result = extractSessionEconomics(session, makeTokenUsage({ totalTokens: 20000 }), convergence);
+    assert.equal(result.tokensPerDecision, 10000);
+  });
+
+  it("returns Infinity when no decisions detected", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+    ]);
+    const convergence = makeConvergence({ exchanges: 3, decisionEvents: undefined });
+    const result = extractSessionEconomics(session, makeTokenUsage(), convergence);
+    assert.equal(result.tokensPerDecision, Infinity);
+  });
+
+  it("returns Infinity when decisionEvents is empty array", () => {
+    const session = createSessionFile([
+      { type: "user", timestamp: "2026-04-08T10:00:00.000Z" },
+      { type: "assistant", timestamp: "2026-04-08T10:01:00.000Z" },
+    ]);
+    const convergence = makeConvergence({ exchanges: 3, decisionEvents: [] });
+    const result = extractSessionEconomics(session, makeTokenUsage(), convergence);
+    assert.equal(result.tokensPerDecision, Infinity);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx tsc && node --test dist/extractors/session-economics.test.js`
+Expected: All tests PASS (tokensPerDecision logic already implemented in Task 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/extractors/session-economics.test.ts
+git commit -m "test: add tokensPerDecision tests for session-economics (#55)"
+```
+
+---
+
+### Task 6: Add computeSessionROI and wire into runPulse
+
+**Files:**
+- Modify: `src/commands/pulse.ts`
+
+- [ ] **Step 1: Add import for session-economics extractor**
+
+Add to the imports at the top of `src/commands/pulse.ts`:
+
+```typescript
+import { extractSessionEconomics } from "../extractors/session-economics.js";
+```
+
+- [ ] **Step 2: Add computeSessionROI function**
+
+Add after the existing `computeLeverage` function in `pulse.ts`:
+
+```typescript
+export function computeSessionROI(
+  convergence: PulseReport["convergence"],
+  economics: PulseReport["sessionEconomics"],
+  decisionQuality: PulseReport["decisionQuality"]
+): { score: number; label: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE" } {
+  const decisions = convergence.decisionEvents?.length ?? 0;
+  const { exchanges, outcomes, rate, reworkPercent } = convergence;
+
+  // Yield components
+  const decisionDensity = Math.min(decisions / Math.max(exchanges, 1), 1);
+  const outcomeDensity = Math.min(outcomes / Math.max(exchanges, 1), 1);
+  const convergenceEfficiency = 1 / (1 + rate);
+  const yield_ = decisionDensity * 0.4 + outcomeDensity * 0.3 + convergenceEfficiency * 0.3;
+
+  // Cost components
+  const tokenBurn = economics.tokensPerDecision === Infinity
+    ? 1
+    : Math.min(economics.tokensPerDecision / 50000, 1);
+  const timeCost = economics.durationMs > 0
+    ? Math.min(economics.idleMs / economics.durationMs, 1)
+    : 0;
+  const instability = reworkPercent / 100 + Math.min(economics.thrashingEpisodes.length * 0.15, 0.45);
+  const cost = tokenBurn * 0.4 + timeCost * 0.3 + instability * 0.3;
+
+  const raw = yield_ / Math.max(cost, 0.1);
+  const score = Math.round(raw * 100) / 100;
+
+  const label: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE" =
+    score >= 1.5 ? "PRODUCTIVE" : score >= 0.8 ? "NEUTRAL" : "EXPENSIVE";
+
+  return { score, label };
+}
+```
+
+- [ ] **Step 3: Wire extractSessionEconomics and computeSessionROI into runPulse**
+
+Update the `runPulse` function. After the `computeLeverage` call, add:
+
+```typescript
+  const sessionEconomics = extractSessionEconomics(sessionFile, tokenUsage, convergence);
+  const { score: sessionROI, label: sessionROILabel } = computeSessionROI(convergence, sessionEconomics, decisionQuality);
+```
+
+And add the new fields to the return object:
+
+```typescript
+  return {
+    // ... existing fields ...
+    leverageScore,
+    sessionEconomics,
+    sessionROI,
+    sessionROILabel,
+  };
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: Errors only in `aggregateReports` (it doesn't return the new fields yet — fixed in Task 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/pulse.ts
+git commit -m "feat: add computeSessionROI and wire session economics into runPulse (#55)"
+```
+
+---
+
+### Task 7: Add SESSION ECONOMICS report section and update summary
+
+**Files:**
+- Modify: `src/commands/pulse.ts`
+
+- [ ] **Step 1: Add formatDuration helper**
+
+Add near the existing `rateLabel` helper:
+
+```typescript
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / 60000);
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60);
+    const mins = totalMinutes % 60;
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
+  return `${totalMinutes}m`;
+}
+```
+
+- [ ] **Step 2: Add SESSION ECONOMICS section to formatReport**
+
+In `formatReport`, after the TOKEN CORRELATION section (after the closing `}`), add:
+
+```typescript
+  // Session Economics
+  const se = report.sessionEconomics;
+  if (se.durationMs > 0 || se.costDollars !== null) {
+    lines.push("SESSION ECONOMICS");
+    if (se.durationMs > 0) {
+      const dur = formatDuration(se.durationMs);
+      const active = formatDuration(se.activeMs);
+      const idle = se.idleGaps > 0 ? `, ${formatDuration(se.idleMs)} idle` : "";
+      lines.push(`  Duration:              ${dur} (${active} active${idle})`);
+    }
+    const decisionCount = report.convergence.decisionEvents?.length ?? 0;
+    if (decisionCount > 0) {
+      const tpd = se.tokensPerDecision === Infinity ? "n/a" : `${(se.tokensPerDecision / 1000).toFixed(1)}k tokens/decision`;
+      lines.push(`  Decisions:             ${decisionCount} detected (${tpd})`);
+    }
+    if (se.thrashingEpisodes.length > 0) {
+      const ep = se.thrashingEpisodes.length;
+      const totalThrashTokens = `~${(se.thrashingTokens / 1000).toFixed(0)}k tokens`;
+      lines.push(`  Thrashing:             ${ep} episode${ep > 1 ? "s" : ""} (${totalThrashTokens})`);
+    }
+    if (se.costDollars !== null) {
+      lines.push(`  Cost:                  $${se.costDollars.toFixed(2)} (estimated)`);
+    }
+    lines.push(`  Session ROI:           ${report.sessionROI.toFixed(2)} (${report.sessionROILabel})`);
+    lines.push("");
+  }
+```
+
+- [ ] **Step 3: Update the summary section to include Session ROI**
+
+Replace the existing summary lines:
+
+```typescript
+  // Summary
+  lines.push(hr);
+  lines.push(`Interaction Leverage:    ${report.leverageScore.toFixed(2)} (${report.interactionLeverage})`);
+  lines.push(hr);
+```
+
+With:
+
+```typescript
+  // Summary
+  lines.push(hr);
+  lines.push(`Interaction Leverage:    ${report.leverageScore.toFixed(2)} (${report.interactionLeverage})`);
+  if (report.sessionEconomics.durationMs > 0 || report.sessionEconomics.costDollars !== null) {
+    lines.push(`Session ROI:             ${report.sessionROI.toFixed(2)} (${report.sessionROILabel})`);
+  }
+  lines.push(hr);
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: Only errors from `aggregateReports` not returning new fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/pulse.ts
+git commit -m "feat: add SESSION ECONOMICS report section and ROI summary (#55)"
+```
+
+---
+
+### Task 8: Update aggregateReports for thread mode
+
+**Files:**
+- Modify: `src/commands/pulse.ts`
+
+- [ ] **Step 1: Add session economics aggregation to aggregateReports**
+
+In `aggregateReports`, before the final `return`, add:
+
+```typescript
+  // Session economics: sum across agents
+  const totalDurationMs = reports.reduce((s, r) => s + r.sessionEconomics.durationMs, 0);
+  const totalActiveMs = reports.reduce((s, r) => s + r.sessionEconomics.activeMs, 0);
+  const totalIdleMs = reports.reduce((s, r) => s + r.sessionEconomics.idleMs, 0);
+  const totalIdleGaps = reports.reduce((s, r) => s + r.sessionEconomics.idleGaps, 0);
+  const allThrashingEpisodes = reports.flatMap((r) => r.sessionEconomics.thrashingEpisodes);
+  const allCosts = reports.map((r) => r.sessionEconomics.costDollars);
+  const anyCostNull = allCosts.some((c) => c === null);
+  const totalCostDollars = anyCostNull ? null : allCosts.reduce((s, c) => s! + c!, 0);
+  const totalDecisions = reports.reduce((s, r) => s + (r.convergence.decisionEvents?.length ?? 0), 0);
+  const aggTokPerDecision = totalDecisions > 0 ? Math.round(totalTokens / totalDecisions) : Infinity;
+  const aggThrashingTokens = allThrashingEpisodes.reduce((s, e) => s + e.estimatedTokens, 0);
+
+  const sessionEconomics = {
+    durationMs: totalDurationMs,
+    activeMs: totalActiveMs,
+    idleMs: totalIdleMs,
+    idleGaps: totalIdleGaps,
+    thrashingEpisodes: allThrashingEpisodes,
+    costDollars: totalCostDollars,
+    tokensPerDecision: aggTokPerDecision,
+    thrashingTokens: aggThrashingTokens,
+  };
+
+  const { score: sessionROI, label: sessionROILabel } = computeSessionROI(convergence, sessionEconomics, decisionQuality);
+```
+
+And add to the return object:
+
+```typescript
+  return {
+    // ... existing fields ...
+    leverageScore,
+    sessionEconomics,
+    sessionROI,
+    sessionROILabel,
+  };
+```
+
+- [ ] **Step 2: Verify full project compiles**
+
+Run: `npx tsc`
+Expected: Clean compilation, no errors.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npm test`
+Expected: All tests pass (same pre-existing failures as before, no new failures).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/pulse.ts
+git commit -m "feat: aggregate session economics in thread mode (#55)"
+```
+
+---
+
+### Task 9: Add ROI scoring tests
+
+**Files:**
+- Modify: `src/commands/pulse.test.ts`
+
+- [ ] **Step 1: Check current pulse.test.ts structure**
+
+Read: `src/commands/pulse.test.ts` to understand existing test patterns.
+
+- [ ] **Step 2: Add computeSessionROI tests**
+
+Append a new `describe` block to `src/commands/pulse.test.ts`:
+
+Add `computeSessionROI` to the existing import from `./pulse.js` (line 6):
+
+```typescript
+import { loadHistoricalScores, formatDelta, runPulse, computeLeverage, computeSessionROI } from "./pulse.js";
+```
+
+Then append a new `describe` block at the end of the file:
+
+```typescript
+describe("computeSessionROI", () => {
+  function makeConvergence(overrides?: Partial<ConvergenceSignal>): ConvergenceSignal {
+    return {
+      exchanges: 5, outcomes: 3, rate: 1.67,
+      reworkInstances: 0, reworkPercent: 0,
+      duplicateCommits: 0, blindRetries: 0, pivot: null,
+      ...overrides,
+    };
+  }
+
+  function makeEconomics(overrides?: Partial<SessionEconomicsSignal>): SessionEconomicsSignal {
+    return {
+      durationMs: 600000, activeMs: 540000, idleMs: 60000, idleGaps: 1,
+      thrashingEpisodes: [], costDollars: null,
+      tokensPerDecision: 10000, thrashingTokens: 0,
+      ...overrides,
+    };
+  }
+
+  function makeDQ(overrides?: Partial<DecisionQualitySignal>): DecisionQualitySignal {
+    return {
+      commitsTotal: 3, commitsWithWhy: 2, commitsWithIssueRef: 1,
+      externalContextProvided: false, commitMessages: [],
+      ...overrides,
+    };
+  }
+
+  it("returns PRODUCTIVE for high-yield, low-cost session", () => {
+    const convergence = makeConvergence({
+      exchanges: 5, outcomes: 5, rate: 1,
+      decisionEvents: [
+        { atExchange: 0, type: "approved", detail: "yes" },
+        { atExchange: 1, type: "delegated", detail: "go" },
+        { atExchange: 2, type: "approved", detail: "lgtm" },
+      ],
+    });
+    const economics = makeEconomics({ tokensPerDecision: 5000, idleMs: 0, durationMs: 600000 });
+    const { score, label } = computeSessionROI(convergence, economics, makeDQ());
+    assert.ok(score >= 1.5);
+    assert.equal(label, "PRODUCTIVE");
+  });
+
+  it("returns EXPENSIVE for no-decision, high-idle session", () => {
+    const convergence = makeConvergence({ exchanges: 10, outcomes: 1, rate: 10, decisionEvents: undefined });
+    const economics = makeEconomics({
+      tokensPerDecision: Infinity, idleMs: 500000, durationMs: 600000,
+      thrashingEpisodes: [{ startExchange: 0, endExchange: 9, exchanges: 10, estimatedTokens: 50000 }],
+    });
+    const { score, label } = computeSessionROI(convergence, economics, makeDQ());
+    assert.ok(score < 0.8);
+    assert.equal(label, "EXPENSIVE");
+  });
+
+  it("returns NEUTRAL for average session", () => {
+    const convergence = makeConvergence({
+      exchanges: 5, outcomes: 3, rate: 1.67,
+      decisionEvents: [{ atExchange: 2, type: "approved", detail: "ok" }],
+    });
+    const economics = makeEconomics({ tokensPerDecision: 20000, idleMs: 100000, durationMs: 600000 });
+    const { score, label } = computeSessionROI(convergence, economics, makeDQ());
+    assert.ok(score >= 0.8 && score < 1.5);
+    assert.equal(label, "NEUTRAL");
+  });
+
+  it("handles zero exchanges gracefully", () => {
+    const convergence = makeConvergence({ exchanges: 0, outcomes: 0, rate: 0 });
+    const economics = makeEconomics({ durationMs: 0, idleMs: 0, tokensPerDecision: Infinity });
+    const { score, label } = computeSessionROI(convergence, economics, makeDQ());
+    assert.ok(typeof score === "number");
+    assert.ok(!isNaN(score));
+    assert.ok(["PRODUCTIVE", "NEUTRAL", "EXPENSIVE"].includes(label));
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `npx tsc && node --test dist/commands/pulse.test.js`
+Expected: All ROI tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/pulse.test.ts
+git commit -m "test: add computeSessionROI tests (#55)"
+```
+
+---
+
+### Task 10: Dogfood validation on real sessions
+
+**Files:** None modified — validation only.
+
+- [ ] **Step 1: Build and run pulse on Session 1**
+
+Run:
+```bash
+npm run build && node dist/cli.js run /home/yamakei/Documents/ayumi/.worktrees/1490459966765793411 \
+  --session ~/.claude/projects/-home-yamakei-Documents-ayumi--worktrees-1490459966765793411/5d84c481-09d2-45c3-ab48-4b5a6344cc74.jsonl \
+  --no-llm --no-save
+```
+
+Expected: Report includes new SESSION ECONOMICS section with Duration, Decisions, Session ROI.
+
+- [ ] **Step 2: Run pulse on Session 2**
+
+Run:
+```bash
+node dist/cli.js run /home/yamakei/Documents/ayumi/.worktrees/1490810904764223754 \
+  --session ~/.claude/projects/-home-yamakei-Documents-ayumi--worktrees-1490810904764223754/155c399b-230e-4d37-8430-fb74f6ed6eb6.jsonl \
+  --no-llm --no-save
+```
+
+- [ ] **Step 3: Run pulse on Session 3**
+
+Run:
+```bash
+node dist/cli.js run /home/yamakei/Documents/ayumi/.worktrees/1490459966765793411 \
+  --session ~/.claude/projects/-home-yamakei-Documents-ayumi--worktrees-1490459966765793411/07424cae-8156-4edb-b86b-6ab7b0a29b9d.jsonl \
+  --no-llm --no-save
+```
+
+- [ ] **Step 4: Post findings to issue #55**
+
+Post a comment to issue #55 with the SESSION ECONOMICS output from all 3 sessions, noting:
+- Whether duration/active/idle split looks reasonable
+- Whether thrashing detection fires appropriately
+- Whether dollar cost appears (if model field present)
+- Whether ROI labels match intuition
+
+- [ ] **Step 5: Commit any fixes if needed, then final commit**
+
+```bash
+git add -A
+git commit -m "feat: session economics Phase 2 complete (#55)"
+```

--- a/docs/superpowers/specs/2026-04-08-session-economics-design.md
+++ b/docs/superpowers/specs/2026-04-08-session-economics-design.md
@@ -1,0 +1,222 @@
+# Session Economics — Phase 2 Design Spec
+
+**Date**: 2026-04-08
+**Issue**: #55
+**Depends on**: Phase 1 decision event detection (completed in #55)
+
+## Goal
+
+Add time-awareness and economic scoring to pulse reports. A session becomes a P&L statement: decisions and outcomes produced (yield) vs. tokens, time, and rework consumed (cost). The headline metric is **Session ROI** — a composite that tells the user whether a session was productive relative to its cost.
+
+## Architecture
+
+**Approach C**: New extractor for time/economics, ROI composite in orchestrator.
+
+```
+extractSessionEconomics(sessionPath, tokenUsage, convergence, pricing?)
+  → SessionEconomicsSignal
+
+computeSessionROI(convergence, economics, decisionQuality)
+  → { score, label }
+```
+
+- `session-economics.ts` owns time analysis (duration, active/idle, thrashing) and cost modeling (token pricing)
+- `pulse.ts` computes the ROI composite by combining economics with existing convergence + decision signals — same pattern as `computeLeverage()`
+- Each extractor stays focused on one concern; the orchestrator composes
+
+## Types
+
+### SessionEconomicsSignal
+
+```typescript
+interface SessionEconomicsSignal {
+  /** Wall-clock duration from first to last message (ms) */
+  durationMs: number;
+  /** Time spent with active exchanges — messages < 5min apart (ms) */
+  activeMs: number;
+  /** Estimated idle time — sum of gaps > 5min (ms) */
+  idleMs: number;
+  /** Number of idle gaps detected */
+  idleGaps: number;
+
+  /** Thrashing episodes: stretches of exchanges with no decision events */
+  thrashingEpisodes: ThrashingEpisode[];
+
+  /** Token cost in dollars (null if model pricing unavailable) */
+  costDollars: number | null;
+  /** Tokens spent per decision event (Infinity if 0 decisions) */
+  tokensPerDecision: number;
+  /** Tokens estimated burned during thrashing episodes */
+  thrashingTokens: number;
+}
+
+interface ThrashingEpisode {
+  /** Exchange range (inclusive, 0-based) */
+  startExchange: number;
+  endExchange: number;
+  /** Number of exchanges in this episode */
+  exchanges: number;
+  /** Estimated tokens consumed — proportional allocation */
+  estimatedTokens: number;
+}
+```
+
+### ModelPricing
+
+```typescript
+interface ModelPricing {
+  inputPerMTok: number;   // $ per million input tokens
+  outputPerMTok: number;  // $ per million output tokens
+}
+```
+
+## Extractor: session-economics.ts
+
+### Inputs
+
+| Parameter | Source | Required |
+|-----------|--------|----------|
+| `sessionPath` | CLI / findSessionFile | yes |
+| `tokenUsage: TokenUsageSignal` | token-usage extractor | yes |
+| `convergence: ConvergenceSignal` | convergence extractor | yes |
+
+### Time Analysis
+
+Scan all message timestamps in the session JSONL:
+- **durationMs**: last timestamp minus first timestamp
+- **Idle detection**: any gap > 5 minutes between consecutive messages counts as idle. Sum of all idle gaps = `idleMs`. Count = `idleGaps`.
+- **activeMs**: `durationMs - idleMs`
+
+Works without MPG data — pure session JSONL timestamp analysis.
+
+### Thrashing Detection
+
+Scan exchange indices against `convergence.decisionEvents`:
+- Build a set of exchange indices that have decision events
+- Walk exchanges 0..N. Any sequence of **4+ consecutive exchanges** with no decision event in the range is a thrashing episode. If a session has zero decision events, the entire session is one thrashing episode only if it has 4+ exchanges (avoids flagging short exploratory sessions).
+- Episode token cost: `(episode.exchanges / convergence.exchanges) * tokenUsage.totalTokens`
+- Sum all episode tokens = `thrashingTokens`
+
+### Dollar Cost Model
+
+**Pricing table** (hardcoded constant, no external config):
+
+| Model prefix | Input $/MTok | Output $/MTok |
+|---|---|---|
+| `claude-opus-4` | 15 | 75 |
+| `claude-sonnet-4` | 3 | 15 |
+| `claude-haiku-4` | 0.80 | 4 |
+
+**Model detection**: scan session JSONL assistant messages for the `model` field. Claude Code sessions include this. Use prefix matching for version suffixes (e.g., `claude-opus-4-6` matches `claude-opus-4`).
+
+**Blended cost**: if multiple models appear (e.g., haiku subagents + opus main), sum per-message costs individually rather than applying a single rate.
+
+**Graceful degradation**: if no model field found in session, `costDollars = null`. Report omits the cost line.
+
+### tokensPerDecision
+
+```
+decisionCount = convergence.decisionEvents?.length ?? 0
+tokensPerDecision = decisionCount > 0
+  ? totalTokens / decisionCount
+  : Infinity
+```
+
+Display as `Infinity` → "no decisions detected" in report.
+
+## ROI Composite: computeSessionROI()
+
+Lives in `pulse.ts` alongside `computeLeverage()`.
+
+### Formula
+
+```
+Yield = decisionDensity * 0.4 + outcomeDensity * 0.3 + convergenceEfficiency * 0.3
+  decisionDensity      = min(decisions / max(exchanges, 1), 1)
+  outcomeDensity       = min(outcomes / max(exchanges, 1), 1)
+  convergenceEfficiency = 1 / (1 + rate)
+
+Cost = tokenBurn * 0.4 + timeCost * 0.3 + instability * 0.3
+  tokenBurn    = min(tokensPerDecision / 50000, 1)   // 50k = cost ceiling
+  timeCost     = min(idleMs / max(durationMs, 1), 1) // idle fraction
+  instability  = reworkPercent/100 + min(thrashingEpisodes.length * 0.15, 0.45)
+
+ROI = Yield / max(Cost, 0.1)   // floor to avoid division by zero
+```
+
+### Labels
+
+| ROI | Label |
+|-----|-------|
+| >= 1.5 | PRODUCTIVE |
+| >= 0.8 | NEUTRAL |
+| < 0.8 | EXPENSIVE |
+
+## Report Format
+
+New section after TOKEN CORRELATION:
+
+```
+SESSION ECONOMICS
+  Duration:              47m (38m active, 9m idle)
+  Decisions:             5 detected (12.4k tokens/decision)
+  Thrashing:             1 episode (exchanges 3-8, ~28k tokens)
+  Cost:                  $1.23 (estimated)
+  Session ROI:           1.82 (PRODUCTIVE)
+```
+
+- "Cost" line only appears when `costDollars !== null`
+- "Thrashing" line only appears when episodes > 0
+- Duration formatted as `Xh Ym` or `Xm` depending on length
+
+### Summary line update
+
+```
+──────────────────────────────────────────────────
+Interaction Leverage:    0.64 (MEDIUM)
+Session ROI:             1.82 (PRODUCTIVE)
+──────────────────────────────────────────────────
+```
+
+Both metrics appear. Leverage = interaction quality (steering). ROI = economics (cost vs. yield).
+
+## PulseReport Changes
+
+Add to `PulseReport` interface:
+```typescript
+sessionEconomics: SessionEconomicsSignal;
+sessionROI: number;
+sessionROILabel: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE";
+```
+
+## Orchestration Changes (runPulse)
+
+```typescript
+// After existing extractors:
+const sessionEconomics = extractSessionEconomics(sessionFile, tokenUsage, convergence);
+const { score: sessionROI, label: sessionROILabel } = computeSessionROI(convergence, sessionEconomics, decisionQuality);
+```
+
+## Aggregate Changes (runThreadPulse)
+
+For multi-agent thread reports:
+- Sum `durationMs`, `activeMs`, `idleMs`, `idleGaps` across agents
+- Concatenate `thrashingEpisodes`
+- Sum `costDollars` (null if any agent is null)
+- Recompute `tokensPerDecision` from aggregate totals
+- Recompute ROI from aggregate signals
+
+## Testing
+
+- **Time analysis**: session JSONL with known gaps → verify active/idle split
+- **Thrashing detection**: session with decisions at known exchanges → verify episode boundaries
+- **Dollar cost**: session with known model field → verify cost calculation
+- **Graceful degradation**: session without model field → costDollars is null
+- **ROI scoring**: synthetic signals → verify formula produces expected scores and labels
+- **Zero/edge cases**: empty session, single message, no decisions, all idle
+
+## Non-goals
+
+- No external config file for pricing — hardcoded table, update when new models ship
+- No historical ROI trending — out of scope for Phase 2 (leverage trending already exists)
+- No per-agent ROI in thread mode — aggregate only for now

--- a/src/commands/pulse.test.ts
+++ b/src/commands/pulse.test.ts
@@ -3,7 +3,7 @@ import * as assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadHistoricalScores, formatDelta, runPulse, computeLeverage } from "./pulse.js";
+import { loadHistoricalScores, formatDelta, runPulse, computeLeverage, computeSessionROI } from "./pulse.js";
 
 const tmp = join(tmpdir(), "pulse-coaching-test-" + process.pid);
 
@@ -273,5 +273,78 @@ describe("runPulse with --session path", () => {
     // No session file will be found for tmpDir, so convergence should have 0 exchanges
     const report = await runPulse(tmpDir);
     assert.equal(report.convergence.exchanges, 0);
+  });
+});
+
+describe("computeSessionROI", () => {
+  function makeConv(overrides?: Partial<Record<string, unknown>>): Record<string, unknown> {
+    return {
+      exchanges: 5, outcomes: 3, rate: 1.67,
+      reworkInstances: 0, reworkPercent: 0,
+      duplicateCommits: 0, blindRetries: 0, pivot: null,
+      ...overrides,
+    };
+  }
+
+  function makeEcon(overrides?: Partial<Record<string, unknown>>): Record<string, unknown> {
+    return {
+      durationMs: 600000, activeMs: 540000, idleMs: 60000, idleGaps: 1,
+      thrashingEpisodes: [], costDollars: null,
+      tokensPerDecision: 10000, thrashingTokens: 0,
+      ...overrides,
+    };
+  }
+
+  function makeDQ(): Record<string, unknown> {
+    return {
+      commitsTotal: 3, commitsWithWhy: 2, commitsWithIssueRef: 1,
+      externalContextProvided: false, commitMessages: [],
+    };
+  }
+
+  it("returns PRODUCTIVE for high-yield, low-cost session", () => {
+    const convergence = makeConv({
+      exchanges: 5, outcomes: 5, rate: 1,
+      decisionEvents: [
+        { atExchange: 0, type: "approved", detail: "yes" },
+        { atExchange: 1, type: "delegated", detail: "go" },
+        { atExchange: 2, type: "approved", detail: "lgtm" },
+      ],
+    });
+    const economics = makeEcon({ tokensPerDecision: 5000, idleMs: 0, durationMs: 600000 });
+    const { score, label } = computeSessionROI(convergence as any, economics as any, makeDQ() as any);
+    assert.ok(score >= 1.5);
+    assert.equal(label, "PRODUCTIVE");
+  });
+
+  it("returns EXPENSIVE for no-decision, high-idle session", () => {
+    const convergence = makeConv({ exchanges: 10, outcomes: 1, rate: 10, decisionEvents: undefined });
+    const economics = makeEcon({
+      tokensPerDecision: Infinity, idleMs: 500000, durationMs: 600000,
+      thrashingEpisodes: [{ startExchange: 0, endExchange: 9, exchanges: 10, estimatedTokens: 50000 }],
+    });
+    const { score, label } = computeSessionROI(convergence as any, economics as any, makeDQ() as any);
+    assert.ok(score < 0.8);
+    assert.equal(label, "EXPENSIVE");
+  });
+
+  it("returns NEUTRAL for average session", () => {
+    const convergence = makeConv({
+      exchanges: 10, outcomes: 3, rate: 3.33,
+      decisionEvents: [{ atExchange: 5, type: "approved", detail: "ok" }],
+    });
+    const economics = makeEcon({ tokensPerDecision: 20000, idleMs: 180000, durationMs: 600000 });
+    const { score, label } = computeSessionROI(convergence as any, economics as any, makeDQ() as any);
+    assert.ok(score >= 0.8 && score < 1.5);
+    assert.equal(label, "NEUTRAL");
+  });
+
+  it("handles zero exchanges gracefully", () => {
+    const convergence = makeConv({ exchanges: 0, outcomes: 0, rate: 0 });
+    const economics = makeEcon({ durationMs: 0, idleMs: 0, tokensPerDecision: Infinity });
+    const { score, label } = computeSessionROI(convergence as any, economics as any, makeDQ() as any);
+    assert.ok(typeof score === "number");
+    assert.ok(!isNaN(score));
+    assert.ok(["PRODUCTIVE", "NEUTRAL", "EXPENSIVE"].includes(label));
   });
 });

--- a/src/commands/pulse.test.ts
+++ b/src/commands/pulse.test.ts
@@ -28,6 +28,9 @@ function makeReport(overrides: Record<string, unknown> = {}): Record<string, unk
     },
     interactionLeverage: "MEDIUM",
     leverageScore: 0.55,
+    sessionEconomics: { durationMs: 0, activeMs: 0, idleMs: 0, idleGaps: 0, thrashingEpisodes: [], costDollars: null, tokensPerDecision: Infinity, thrashingTokens: 0 },
+    sessionROI: 0,
+    sessionROILabel: "NEUTRAL",
     ...overrides,
   };
 }

--- a/src/commands/pulse.ts
+++ b/src/commands/pulse.ts
@@ -5,6 +5,7 @@ import { extractDecisionQuality } from "../extractors/decision-quality.js";
 import { extractTokenUsage } from "../extractors/token-usage.js";
 import { extractInteractionPattern } from "../extractors/interaction-pattern.js";
 import { extractPromptEffectiveness } from "../extractors/prompt-effectiveness.js";
+import { extractSessionEconomics } from "../extractors/session-economics.js";
 import { correlateMpgEvents } from "../activity/mpg-correlator.js";
 import { loadReports } from "./history.js";
 import { execSync } from "node:child_process";
@@ -18,12 +19,13 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
   const filesChanged = countFilesChanged(projectDir, timeWindow);
   const mpgData = correlateMpgEvents(sessionFile);
   const convergence = extractConvergence(sessionFile, filesChanged, mpgData);
-  const decisionQuality = extractDecisionQuality(projectDir);
+  const decisionQuality = extractDecisionQuality(projectDir, timeWindow.start ?? undefined);
   const intentAnchoring = extractIntentAnchoring(projectDir, decisionQuality.commitMessages);
   const tokenUsage = extractTokenUsage(sessionFile, convergence.exchanges, convergence.outcomes);
   const interactionPattern = extractInteractionPattern(sessionFile, mpgData);
   const promptEffectiveness = await extractPromptEffectiveness(sessionFile);
   const { score: leverageScore, label: interactionLeverage } = computeLeverage(convergence, decisionQuality);
+  const sessionEconomics = extractSessionEconomics(sessionFile, tokenUsage, convergence);
 
   return {
     timestamp: new Date().toISOString(),
@@ -37,6 +39,9 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
     promptEffectiveness,
     interactionLeverage,
     leverageScore,
+    sessionEconomics,
+    sessionROI: 0,
+    sessionROILabel: "NEUTRAL" as const,
   };
 }
 
@@ -67,6 +72,21 @@ export function formatReport(report: PulseReport): string {
     for (const a of c.agentBreakdown) {
       const penaltyNote = a.convergencePenalty > 0 ? ` (+${a.convergencePenalty} penalty)` : "";
       lines.push(`    ${a.agent.padEnd(16)} ${a.messages} msgs, ${a.errors} errors (${a.errorRate}%)${penaltyNote}`);
+    }
+  }
+  if (c.decisionEvents && c.decisionEvents.length > 0) {
+    lines.push("");
+    lines.push("DECISION EVENTS");
+    lines.push(`  Detected:              ${c.decisionEvents.length}`);
+    const typeCounts: Record<string, number> = {};
+    for (const e of c.decisionEvents) {
+      typeCounts[e.type] = (typeCounts[e.type] || 0) + 1;
+    }
+    for (const [type, count] of Object.entries(typeCounts).sort((a, b) => b[1] - a[1])) {
+      lines.push(`    ${type.padEnd(20)} ${count}x`);
+    }
+    for (const e of c.decisionEvents) {
+      lines.push(`  [${e.atExchange + 1}] ${e.type}: ${e.detail}`);
     }
   }
   lines.push("");
@@ -471,6 +491,7 @@ export function aggregateReports(reports: PulseReport[], project: string): Pulse
 
   // Leverage: compute from aggregate convergence + decision quality
   const { score: leverageScore, label: interactionLeverage } = computeLeverage(convergence, decisionQuality);
+  const aggregateSessionEconomics = extractSessionEconomics(null, tokenUsage, convergence);
 
   return {
     timestamp: new Date().toISOString(),
@@ -484,6 +505,9 @@ export function aggregateReports(reports: PulseReport[], project: string): Pulse
     promptEffectiveness,
     interactionLeverage,
     leverageScore,
+    sessionEconomics: aggregateSessionEconomics,
+    sessionROI: 0,
+    sessionROILabel: "NEUTRAL" as const,
   };
 }
 

--- a/src/commands/pulse.ts
+++ b/src/commands/pulse.ts
@@ -26,6 +26,7 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
   const promptEffectiveness = await extractPromptEffectiveness(sessionFile);
   const { score: leverageScore, label: interactionLeverage } = computeLeverage(convergence, decisionQuality);
   const sessionEconomics = extractSessionEconomics(sessionFile, tokenUsage, convergence);
+  const { score: sessionROI, label: sessionROILabel } = computeSessionROI(convergence, sessionEconomics, decisionQuality);
 
   return {
     timestamp: new Date().toISOString(),
@@ -40,8 +41,8 @@ export async function runPulse(projectDir: string, sessionPath?: string): Promis
     interactionLeverage,
     leverageScore,
     sessionEconomics,
-    sessionROI: 0,
-    sessionROILabel: "NEUTRAL" as const,
+    sessionROI,
+    sessionROILabel,
   };
 }
 
@@ -126,6 +127,33 @@ export function formatReport(report: PulseReport): string {
     lines.push("");
   }
 
+  // Session Economics
+  const se = report.sessionEconomics;
+  if (se.durationMs > 0 || se.costDollars !== null) {
+    lines.push("SESSION ECONOMICS");
+    if (se.durationMs > 0) {
+      const dur = formatDuration(se.durationMs);
+      const active = formatDuration(se.activeMs);
+      const idle = se.idleGaps > 0 ? `, ${formatDuration(se.idleMs)} idle` : "";
+      lines.push(`  Duration:              ${dur} (${active} active${idle})`);
+    }
+    const decisionCount = report.convergence.decisionEvents?.length ?? 0;
+    if (decisionCount > 0) {
+      const tpd = se.tokensPerDecision === Infinity ? "n/a" : `${(se.tokensPerDecision / 1000).toFixed(1)}k tokens/decision`;
+      lines.push(`  Decisions:             ${decisionCount} detected (${tpd})`);
+    }
+    if (se.thrashingEpisodes.length > 0) {
+      const ep = se.thrashingEpisodes.length;
+      const totalThrashTokens = `~${(se.thrashingTokens / 1000).toFixed(0)}k tokens`;
+      lines.push(`  Thrashing:             ${ep} episode${ep > 1 ? "s" : ""} (${totalThrashTokens})`);
+    }
+    if (se.costDollars !== null) {
+      lines.push(`  Cost:                  $${se.costDollars.toFixed(2)} (estimated)`);
+    }
+    lines.push(`  Session ROI:           ${report.sessionROI.toFixed(2)} (${report.sessionROILabel})`);
+    lines.push("");
+  }
+
   // Interaction Pattern
   lines.push("INTERACTION PATTERN");
   lines.push(`  User style:            ${ip.userStyle}`);
@@ -180,6 +208,9 @@ export function formatReport(report: PulseReport): string {
   // Summary
   lines.push(hr);
   lines.push(`Interaction Leverage:    ${report.leverageScore.toFixed(2)} (${report.interactionLeverage})`);
+  if (report.sessionEconomics.durationMs > 0 || report.sessionEconomics.costDollars !== null) {
+    lines.push(`Session ROI:             ${report.sessionROI.toFixed(2)} (${report.sessionROILabel})`);
+  }
   lines.push(hr);
 
   // Actionable nudges
@@ -260,11 +291,54 @@ export function computeLeverage(
   return { score, label };
 }
 
+export function computeSessionROI(
+  convergence: PulseReport["convergence"],
+  economics: PulseReport["sessionEconomics"],
+  decisionQuality: PulseReport["decisionQuality"]
+): { score: number; label: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE" } {
+  const decisions = convergence.decisionEvents?.length ?? 0;
+  const { exchanges, outcomes, rate, reworkPercent } = convergence;
+
+  // Yield components
+  const decisionDensity = Math.min(decisions / Math.max(exchanges, 1), 1);
+  const outcomeDensity = Math.min(outcomes / Math.max(exchanges, 1), 1);
+  const convergenceEfficiency = 1 / (1 + rate);
+  const yield_ = decisionDensity * 0.4 + outcomeDensity * 0.3 + convergenceEfficiency * 0.3;
+
+  // Cost components
+  const tokenBurn = economics.tokensPerDecision === Infinity
+    ? 1
+    : Math.min(economics.tokensPerDecision / 50000, 1);
+  const timeCost = economics.durationMs > 0
+    ? Math.min(economics.idleMs / economics.durationMs, 1)
+    : 0;
+  const instability = reworkPercent / 100 + Math.min(economics.thrashingEpisodes.length * 0.15, 0.45);
+  const cost = tokenBurn * 0.4 + timeCost * 0.3 + instability * 0.3;
+
+  const raw = yield_ / Math.max(cost, 0.1);
+  const score = Math.round(raw * 100) / 100;
+
+  const label: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE" =
+    score >= 1.5 ? "PRODUCTIVE" : score >= 0.8 ? "NEUTRAL" : "EXPENSIVE";
+
+  return { score, label };
+}
+
 function rateLabel(rate: number): string {
   if (rate <= 0.5) return "excellent";
   if (rate <= 1.5) return "good";
   if (rate <= 4) return "moderate";
   return "high — consider clearer problem framing";
+}
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / 60000);
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60);
+    const mins = totalMinutes % 60;
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
+  return `${totalMinutes}m`;
 }
 
 function generateNudges(report: PulseReport): string[] {
@@ -491,7 +565,32 @@ export function aggregateReports(reports: PulseReport[], project: string): Pulse
 
   // Leverage: compute from aggregate convergence + decision quality
   const { score: leverageScore, label: interactionLeverage } = computeLeverage(convergence, decisionQuality);
-  const aggregateSessionEconomics = extractSessionEconomics(null, tokenUsage, convergence);
+
+  // Session economics: sum across agents
+  const totalDurationMs = reports.reduce((s, r) => s + r.sessionEconomics.durationMs, 0);
+  const totalActiveMs = reports.reduce((s, r) => s + r.sessionEconomics.activeMs, 0);
+  const totalIdleMs = reports.reduce((s, r) => s + r.sessionEconomics.idleMs, 0);
+  const totalIdleGaps = reports.reduce((s, r) => s + r.sessionEconomics.idleGaps, 0);
+  const allThrashingEpisodes = reports.flatMap((r) => r.sessionEconomics.thrashingEpisodes);
+  const allCosts = reports.map((r) => r.sessionEconomics.costDollars);
+  const anyCostNull = allCosts.some((c) => c === null);
+  const totalCostDollars = anyCostNull ? null : allCosts.reduce((s, c) => s! + c!, 0);
+  const totalDecisions = reports.reduce((s, r) => s + (r.convergence.decisionEvents?.length ?? 0), 0);
+  const aggTokPerDecision = totalDecisions > 0 ? Math.round(totalTokens / totalDecisions) : Infinity;
+  const aggThrashingTokens = allThrashingEpisodes.reduce((s, e) => s + e.estimatedTokens, 0);
+
+  const sessionEconomics = {
+    durationMs: totalDurationMs,
+    activeMs: totalActiveMs,
+    idleMs: totalIdleMs,
+    idleGaps: totalIdleGaps,
+    thrashingEpisodes: allThrashingEpisodes,
+    costDollars: totalCostDollars,
+    tokensPerDecision: aggTokPerDecision,
+    thrashingTokens: aggThrashingTokens,
+  };
+
+  const { score: sessionROI, label: sessionROILabel } = computeSessionROI(convergence, sessionEconomics, decisionQuality);
 
   return {
     timestamp: new Date().toISOString(),
@@ -505,9 +604,9 @@ export function aggregateReports(reports: PulseReport[], project: string): Pulse
     promptEffectiveness,
     interactionLeverage,
     leverageScore,
-    sessionEconomics: aggregateSessionEconomics,
-    sessionROI: 0,
-    sessionROILabel: "NEUTRAL" as const,
+    sessionEconomics,
+    sessionROI,
+    sessionROILabel,
   };
 }
 

--- a/src/commands/thread-pulse.test.ts
+++ b/src/commands/thread-pulse.test.ts
@@ -24,6 +24,9 @@ function makeReport(overrides: Record<string, unknown> = {}): PulseReport {
     },
     interactionLeverage: "MEDIUM",
     leverageScore: 0.55,
+    sessionEconomics: { durationMs: 600000, activeMs: 540000, idleMs: 60000, idleGaps: 1, thrashingEpisodes: [], costDollars: null, tokensPerDecision: 10000, thrashingTokens: 0 },
+    sessionROI: 1.0,
+    sessionROILabel: "NEUTRAL",
     ...overrides,
   } as unknown as PulseReport;
 }

--- a/src/extractors/convergence.test.ts
+++ b/src/extractors/convergence.test.ts
@@ -436,4 +436,190 @@ describe("MPG enrichment — per-agent convergence", () => {
     const breakdown = computeAgentBreakdown(mpgData);
     assert.equal(breakdown[0].agent, "reviewer");
   });
+
+  it("derives agent name from session_id colon format", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test",
+      events: [
+        makeMpgEvent({ agent_target: undefined, persona: undefined, session_id: "1490459:pm" }),
+      ],
+    };
+    const breakdown = computeAgentBreakdown(mpgData);
+    assert.equal(breakdown[0].agent, "pm");
+  });
+
+  it("derives agent name from project_dir suffix", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test",
+      events: [
+        makeMpgEvent({ agent_target: undefined, persona: undefined, session_id: "some-uuid", project_dir: "/home/user/proj/.worktrees/123-engineer" }),
+      ],
+    };
+    const breakdown = computeAgentBreakdown(mpgData);
+    assert.equal(breakdown[0].agent, "engineer");
+  });
+
+  it("falls back to 'main' when no agent info available", () => {
+    const mpgData: CorrelatedMpgData = {
+      sessionId: "test",
+      events: [
+        makeMpgEvent({ agent_target: undefined, persona: undefined, session_id: "some-uuid", project_dir: "/home/user/proj/.worktrees/14904599" }),
+      ],
+    };
+    const breakdown = computeAgentBreakdown(mpgData);
+    assert.equal(breakdown[0].agent, "main");
+  });
+});
+
+describe("decision event detection", () => {
+  it("detects option selection from bare digit", () => {
+    const session = createSessionFile([
+      { type: "user", content: "1" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents!.length, 1);
+    assert.equal(result.decisionEvents![0].type, "option_selected");
+  });
+
+  it("detects option selection from bare letter", () => {
+    const session = createSessionFile([
+      { type: "user", content: "B" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "option_selected");
+  });
+
+  it("detects 'the first option' as option selection", () => {
+    const session = createSessionFile([
+      { type: "user", content: "the first one" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "option_selected");
+  });
+
+  it("detects scope decision language", () => {
+    const session = createSessionFile([
+      { type: "user", content: "We do not plan to add support for voice-samples.md" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "scope_decided");
+  });
+
+  it("detects 'skip that' as scope decision", () => {
+    const session = createSessionFile([
+      { type: "user", content: "skip that for now" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "scope_decided");
+  });
+
+  it("detects delegation patterns", () => {
+    const session = createSessionFile([
+      { type: "user", content: "Can you run the extraction pipeline?" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "delegated");
+  });
+
+  it("detects 'proceed' as delegation", () => {
+    const session = createSessionFile([
+      { type: "user", content: "proceed" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "delegated");
+  });
+
+  it("detects approval patterns", () => {
+    const session = createSessionFile([
+      { type: "user", content: "looks good" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "approved");
+  });
+
+  it("detects 'merge' as approval", () => {
+    const session = createSessionFile([
+      { type: "user", content: "merge" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "approved");
+  });
+
+  it("detects 'yes' as approval", () => {
+    const session = createSessionFile([
+      { type: "user", content: "yes" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.equal(result.decisionEvents![0].type, "approved");
+  });
+
+  it("detects rejection patterns", () => {
+    const session = createSessionFile([
+      { type: "user", content: "don't do that, it's wrong" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.ok(result.decisionEvents!.some(e => e.type === "rejected"));
+  });
+
+  it("does not detect decisions in normal instructions", () => {
+    const session = createSessionFile([
+      { type: "user", content: "add a login form to the page" },
+      { type: "user", content: "now add validation for the email field" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.equal(result.decisionEvents, undefined);
+  });
+
+  it("detects multiple decision types in one session", () => {
+    const session = createSessionFile([
+      { type: "user", content: "1" },
+      { type: "user", content: "We don't plan to add voice support" },
+      { type: "user", content: "Can you run the tests?" },
+      { type: "user", content: "looks good" },
+      { type: "user", content: "merge" },
+    ]);
+    const result = extractConvergence(session, 1);
+    assert.ok(result.decisionEvents);
+    assert.ok(result.decisionEvents!.length >= 4);
+    const types = new Set(result.decisionEvents!.map(e => e.type));
+    assert.ok(types.has("option_selected"));
+    assert.ok(types.has("scope_decided"));
+    assert.ok(types.has("delegated"));
+    assert.ok(types.has("approved"));
+  });
+});
+
+describe("heredoc commit message extraction", () => {
+  it("extracts issue refs from heredoc-style commit messages", () => {
+    const session = createRawSessionFile([
+      userMsg("commit the changes"),
+      toolUseMsg("Bash", { command: "git commit -m \"$(cat <<'EOF'\nfeat: add vault consolidation (#36)\n\nCo-Authored-By: Claude\nEOF\n)\"" }),
+      toolUseMsg("Bash", { command: "git commit -m \"$(cat <<'EOF'\nfix: address review issues (#36)\n\nCo-Authored-By: Claude\nEOF\n)\"" }),
+    ]);
+    const result = extractConvergence(session, 0);
+    // Both reference #36, so second should be deduplicated
+    assert.equal(result.duplicateCommits, 1);
+  });
+
+  it("counts heredoc commits without issue refs individually", () => {
+    const session = createRawSessionFile([
+      userMsg("commit"),
+      toolUseMsg("Bash", { command: "git commit -m \"$(cat <<'EOF'\nfeat: add new feature\n\nCo-Authored-By: Claude\nEOF\n)\"" }),
+      toolUseMsg("Bash", { command: "git commit -m \"$(cat <<'EOF'\nfix: a different fix\nEOF\n)\"" }),
+    ]);
+    const result = extractConvergence(session, 0);
+    assert.equal(result.outcomes, 2);
+    assert.equal(result.duplicateCommits, 0);
+  });
 });

--- a/src/extractors/convergence.ts
+++ b/src/extractors/convergence.ts
@@ -1,4 +1,4 @@
-import { ConvergenceSignal, PivotSignal, AgentConvergenceStats, CorrelatedMpgData } from "../types/pulse.js";
+import { ConvergenceSignal, PivotSignal, AgentConvergenceStats, CorrelatedMpgData, DecisionEvent } from "../types/pulse.js";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -38,6 +38,7 @@ export function extractConvergence(
   let duplicateCommits = 0;
   let blindRetries = 0;
   let pivot: PivotSignal | null = null;
+  let decisionEvents: DecisionEvent[] = [];
 
   if (sessionPath) {
     const parsed = parseSessionMessages(sessionPath);
@@ -47,6 +48,7 @@ export function extractConvergence(
     duplicateCommits = parsed.duplicateCommits;
     blindRetries = parsed.blindRetries;
     pivot = parsed.pivot;
+    decisionEvents = parsed.decisionEvents;
   }
 
   // Outcomes: max of session-derived outcomes and git filesChanged. Floor at 1 to avoid division by zero.
@@ -64,6 +66,11 @@ export function extractConvergence(
     signal.agentBreakdown = computeAgentBreakdown(mpgData);
   }
 
+  // Attach decision events when detected
+  if (decisionEvents.length > 0) {
+    signal.decisionEvents = decisionEvents;
+  }
+
   return signal;
 }
 
@@ -77,7 +84,7 @@ export function computeAgentBreakdown(mpgData: CorrelatedMpgData): AgentConverge
 
   for (const event of mpgData.events) {
     if (event.event_type !== "message_routed") continue;
-    const agent = event.agent_target || event.persona || "unknown";
+    const agent = event.agent_target || event.persona || agentFromContext(event);
     const entry = agentMap.get(agent) || { messages: 0, errors: 0 };
     entry.messages++;
     if (event.is_error) entry.errors++;
@@ -234,10 +241,62 @@ const ROOT_CAUSE_REQUEST_PATTERNS = [
   /\bwhy (?:is|does|did) (?:this|it)\b/i,
 ];
 
+// ── Decision event detection patterns (#55) ──────────────────────────
+
+/** Option selection: user picks from alternatives ("1", "a", "B", "option 2") */
+const OPTION_SELECTION_PATTERNS = [
+  /^[1-9]$/,                             // bare digit
+  /^[a-cA-C]$/,                          // bare letter option (a/b/c)
+  /^(?:option|choice|go with|pick)\s*[1-9a-c]\b/i,
+  /^(?:the )?(?:first|second|third|last) (?:one|option|approach|plan)\b/i,
+];
+
+/** Scope decision: user narrows or excludes scope */
+const SCOPE_DECISION_PATTERNS = [
+  /\b(?:do not|don'?t|won'?t|will not|no need to) (?:plan|add|support|implement|include|build|create)\b/i,
+  /\bskip\s+(?:that|this|the|it)\b/i,
+  /\bout of scope\b/i,
+  /\bnot (?:needed|necessary|required|planned)\b/i,
+  /\bwe (?:do not|don'?t) (?:plan|need|want) to\b/i,
+  /\bdrop\s+(?:that|this|the|it)\b/i,
+  /\bremove\s+(?:that|this|the) (?:feature|requirement|support)\b/i,
+];
+
+/** Delegation: user directs work to an agent or process */
+const DELEGATION_PATTERNS = [
+  /\bhand\s*(?:off|it over)\b/i,
+  /\bcan you (?:run|execute|do|handle|take care of|proceed|start|fix)\b/i,
+  /\bplease (?:run|execute|do|handle|proceed|start|fix)\b/i,
+  /\bgo ahead\b/i,
+  /\bproceed\b/i,
+];
+
+/** Approval: user accepts work */
+const APPROVAL_PATTERNS = [
+  /\blooks? good\b/i,
+  /\blgtm\b/i,
+  /\bapproved?\b/i,
+  /^(?:merge|commit|ship|deploy|push)(?:\s+(?:it|this|that|the PR|pr))?\.?$/im,
+  /\bmerge (?:it|this|that|the )?(?:PR|pr|pull request)\b/i,
+  /\bmerge directly\b/i,
+  /\byes[,.]?\s*(?:do it|go ahead|proceed|that'?s? (?:right|correct|fine|good))/i,
+  /^(?:yes|yep|yeah|correct|right|exactly)\.?$/im,
+];
+
+/** Rejection: user explicitly rejects a proposal */
+const REJECTION_PATTERNS = [
+  /\bdon'?t (?:do|use|go with) (?:that|this|it)\b/i,
+  /\bno[,.]?\s*(?:that'?s? (?:not|wrong)|don'?t|skip|not that)/i,
+  /\breject(?:ed)?\b/i,
+  /\bnot (?:that|this) (?:one|approach|option|way)\b/i,
+];
+
 const GIT_COMMIT_RE = /\bgit\s+commit\b/;
 const GH_PR_CREATE_RE = /\bgh\s+pr\s+create\b/;
 const GH_ISSUE_CREATE_RE = /\bgh\s+issue\s+create\b/;
 const COMMIT_MSG_RE = /-m\s+(?:"([^"]*?)"|'([^']*?)')/;
+/** Heredoc-style: git commit -m "$(cat <<'EOF'\n...\nEOF\n)" */
+const HEREDOC_MSG_RE = /cat\s+<<'?EOF'?\n([\s\S]*?)\nEOF/;
 const ISSUE_REF_RE = /#(\d+)/g;
 
 function parseSessionMessages(sessionPath: string): {
@@ -247,6 +306,7 @@ function parseSessionMessages(sessionPath: string): {
   duplicateCommits: number;
   blindRetries: number;
   pivot: PivotSignal | null;
+  decisionEvents: DecisionEvent[];
 } {
   let exchanges = 0;
   let reworkInstances = 0;
@@ -259,6 +319,7 @@ function parseSessionMessages(sessionPath: string): {
 
   // Track message flow for blind-retry and pivot detection
   const messageClasses: Array<"rework" | "diagnostic" | "pivot_issue" | "pivot_rootcause" | "other"> = [];
+  const decisionEvents: DecisionEvent[] = [];
   let agentActedSinceLastUser = false;
 
   try {
@@ -297,6 +358,25 @@ function parseSessionMessages(sessionPath: string): {
             messageClasses.push("other");
           }
 
+          // Decision event detection (#55)
+          const exchangeIdx = exchanges - 1;
+          const trimmed = text.trim();
+          if (OPTION_SELECTION_PATTERNS.some(p => p.test(trimmed))) {
+            decisionEvents.push({ atExchange: exchangeIdx, type: "option_selected", detail: `selected "${trimmed}"` });
+          }
+          if (SCOPE_DECISION_PATTERNS.some(p => p.test(text))) {
+            decisionEvents.push({ atExchange: exchangeIdx, type: "scope_decided", detail: text.slice(0, 80) });
+          }
+          if (DELEGATION_PATTERNS.some(p => p.test(text))) {
+            decisionEvents.push({ atExchange: exchangeIdx, type: "delegated", detail: text.slice(0, 80) });
+          }
+          if (APPROVAL_PATTERNS.some(p => p.test(trimmed))) {
+            decisionEvents.push({ atExchange: exchangeIdx, type: "approved", detail: trimmed.slice(0, 80) });
+          }
+          if (REJECTION_PATTERNS.some(p => p.test(text))) {
+            decisionEvents.push({ atExchange: exchangeIdx, type: "rejected", detail: text.slice(0, 80) });
+          }
+
           agentActedSinceLastUser = false;
         } else if (msg.type === "assistant") {
           const blocks = msg.message?.content;
@@ -316,7 +396,8 @@ function parseSessionMessages(sessionPath: string): {
               if (GIT_COMMIT_RE.test(cmd)) {
                 // Deduplicate commits by issue ref
                 const msgMatch = cmd.match(COMMIT_MSG_RE);
-                const commitMsg = msgMatch ? (msgMatch[1] ?? msgMatch[2] ?? "") : "";
+                const heredocMatch = !msgMatch ? cmd.match(HEREDOC_MSG_RE) : null;
+                const commitMsg = msgMatch ? (msgMatch[1] ?? msgMatch[2] ?? "") : (heredocMatch ? heredocMatch[1] : "");
                 const refs: string[] = [];
                 let refMatch: RegExpExecArray | null;
                 const issueRe = new RegExp(ISSUE_REF_RE.source, "g");
@@ -354,7 +435,7 @@ function parseSessionMessages(sessionPath: string): {
   const blindRetries = detectBlindRetries(messageClasses);
   const pivot = detectPivot(messageClasses);
 
-  return { exchanges, reworkInstances, outcomes, duplicateCommits, blindRetries, pivot };
+  return { exchanges, reworkInstances, outcomes, duplicateCommits, blindRetries, pivot, decisionEvents };
 }
 
 /**
@@ -431,6 +512,26 @@ function isSystemMessage(text: string): boolean {
     text.startsWith("Base directory for this skill:") ||
     text.includes("/.claude/plugins/")
   );
+}
+
+/**
+ * Derive agent name from MPG event context when agent_target and persona are unset.
+ * Checks session_id ("worktreeId:role") and project_dir suffix ("-role").
+ */
+function agentFromContext(event: { session_id: string; project_dir: string }): string {
+  // session_id format: "1490459966765793411:pm" → "pm"
+  const colonIdx = event.session_id.indexOf(":");
+  if (colonIdx > 0) {
+    return event.session_id.slice(colonIdx + 1);
+  }
+  // project_dir format: ".../worktrees/1490459966765793411-pm" → "pm"
+  const dirMatch = event.project_dir.match(/-(\w[\w-]*)$/);
+  if (dirMatch) {
+    // Exclude numeric-only suffixes (worktree IDs)
+    const candidate = dirMatch[1];
+    if (!/^\d+$/.test(candidate)) return candidate;
+  }
+  return "main";
 }
 
 function round(n: number, decimals: number): number {

--- a/src/extractors/session-economics.test.ts
+++ b/src/extractors/session-economics.test.ts
@@ -90,7 +90,7 @@ describe("extractSessionEconomics - time analysis", () => {
     const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
     assert.equal(result.idleGaps, 1);
     assert.equal(result.idleMs, 600000);
-    assert.equal(result.activeMs, 120000);
+    assert.equal(result.activeMs, 240000); // 14min total - 10min idle = 4min active
   });
 
   it("does not flag gaps <= 5 minutes as idle", () => {

--- a/src/extractors/session-economics.test.ts
+++ b/src/extractors/session-economics.test.ts
@@ -186,3 +186,53 @@ describe("extractSessionEconomics - thrashing detection", () => {
     assert.equal(result.thrashingEpisodes.length, 0);
   });
 });
+
+// ── Task 4: Dollar cost model ─────────────────────────────────────────────────
+
+describe("extractSessionEconomics - cost model", () => {
+  it("computes cost from model pricing in session JSONL", () => {
+    // opus: input=$15/MTok, output=$75/MTok
+    // message1: 1000 input + 500 output
+    // message2: 2000 input + 1000 output
+    // total: 3000 input + 1500 output
+    // cost = 3000/1e6*15 + 1500/1e6*75 = 0.045 + 0.1125 = 0.1575
+    const filePath = createSessionFile([
+      { type: "assistant", timestamp: "2024-01-01T10:00:00.000Z", model: "claude-opus-4-5", input_tokens: 1000, output_tokens: 500 },
+      { type: "assistant", timestamp: "2024-01-01T10:01:00.000Z", model: "claude-opus-4-5", input_tokens: 2000, output_tokens: 1000 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.costDollars, 0.1575);
+  });
+
+  it("returns null cost when no model field in session", () => {
+    const filePath = createSessionFile([
+      { type: "assistant", timestamp: "2024-01-01T10:00:00.000Z", input_tokens: 1000, output_tokens: 500 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.costDollars, null);
+  });
+
+  it("handles blended cost with multiple models", () => {
+    // opus message: 1000 input + 500 output → 0.015 + 0.0375 = 0.0525
+    // haiku message: 1000 input + 500 output → 0.0008 + 0.002 = 0.0028
+    // total ≈ 0.0553 — between 0.05 and 0.07
+    const filePath = createSessionFile([
+      { type: "assistant", timestamp: "2024-01-01T10:00:00.000Z", model: "claude-opus-4-5", input_tokens: 1000, output_tokens: 500 },
+      { type: "assistant", timestamp: "2024-01-01T10:01:00.000Z", model: "claude-haiku-4-5", input_tokens: 1000, output_tokens: 500 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.ok(result.costDollars !== null);
+    assert.ok(result.costDollars! > 0.05 && result.costDollars! < 0.07);
+  });
+
+  it("uses prefix matching for model versions", () => {
+    // "claude-sonnet-4-6" should match "claude-sonnet-4" pricing
+    // sonnet: input=$3/MTok, output=$15/MTok
+    // 1000 input + 500 output → 0.003 + 0.0075 = 0.0105
+    const filePath = createSessionFile([
+      { type: "assistant", timestamp: "2024-01-01T10:00:00.000Z", model: "claude-sonnet-4-6", input_tokens: 1000, output_tokens: 500 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.costDollars, 0.0105);
+  });
+});

--- a/src/extractors/session-economics.test.ts
+++ b/src/extractors/session-economics.test.ts
@@ -236,3 +236,31 @@ describe("extractSessionEconomics - cost model", () => {
     assert.equal(result.costDollars, 0.0105);
   });
 });
+
+// ── Task 5: tokensPerDecision ─────────────────────────────────────────────────
+
+describe("extractSessionEconomics - tokensPerDecision", () => {
+  it("computes tokens per decision from total tokens and decision count", () => {
+    const convergence = makeConvergence({
+      decisionEvents: [
+        { atExchange: 1, type: "approved", detail: "a" },
+        { atExchange: 3, type: "approved", detail: "b" },
+      ],
+    });
+    const tokenUsage = makeTokenUsage({ totalTokens: 20000 });
+    const result = extractSessionEconomics(null, tokenUsage, convergence);
+    assert.equal(result.tokensPerDecision, 10000);
+  });
+
+  it("returns Infinity when no decisions detected", () => {
+    const convergence = makeConvergence({ decisionEvents: undefined });
+    const result = extractSessionEconomics(null, makeTokenUsage(), convergence);
+    assert.equal(result.tokensPerDecision, Infinity);
+  });
+
+  it("returns Infinity when decisionEvents is empty array", () => {
+    const convergence = makeConvergence({ decisionEvents: [] });
+    const result = extractSessionEconomics(null, makeTokenUsage(), convergence);
+    assert.equal(result.tokensPerDecision, Infinity);
+  });
+});

--- a/src/extractors/session-economics.test.ts
+++ b/src/extractors/session-economics.test.ts
@@ -120,3 +120,69 @@ describe("extractSessionEconomics - time analysis", () => {
     assert.equal(result.durationMs, 0);
   });
 });
+
+// ── Task 3: Thrashing detection ───────────────────────────────────────────────
+
+describe("extractSessionEconomics - thrashing detection", () => {
+  it("detects thrashing when 4+ exchanges have no decisions", () => {
+    // 5 exchanges, decision at 0 → episode at 1-4
+    const convergence = makeConvergence({
+      exchanges: 5,
+      decisionEvents: [{ atExchange: 0, type: "approved", detail: "approved" }],
+    });
+    const tokenUsage = makeTokenUsage({ totalTokens: 50000 });
+    const result = extractSessionEconomics(null, tokenUsage, convergence);
+    assert.equal(result.thrashingEpisodes.length, 1);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 1);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+    assert.equal(result.thrashingEpisodes[0].estimatedTokens, 40000);
+  });
+
+  it("does not flag thrashing for sequences < 4 exchanges", () => {
+    const convergence = makeConvergence({
+      exchanges: 3,
+      decisionEvents: [{ atExchange: 0, type: "approved", detail: "approved" }],
+    });
+    const result = extractSessionEconomics(null, makeTokenUsage(), convergence);
+    assert.equal(result.thrashingEpisodes.length, 0);
+  });
+
+  it("detects multiple thrashing episodes separated by decisions", () => {
+    // 10 exchanges, decisions at 0 and 5 → episodes at 1-4 and 6-9
+    const convergence = makeConvergence({
+      exchanges: 10,
+      decisionEvents: [
+        { atExchange: 0, type: "approved", detail: "approved" },
+        { atExchange: 5, type: "approved", detail: "approved" },
+      ],
+    });
+    const tokenUsage = makeTokenUsage({ totalTokens: 100000 });
+    const result = extractSessionEconomics(null, tokenUsage, convergence);
+    assert.equal(result.thrashingEpisodes.length, 2);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 1);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+    assert.equal(result.thrashingEpisodes[1].startExchange, 6);
+    assert.equal(result.thrashingEpisodes[1].endExchange, 9);
+  });
+
+  it("flags entire session as thrashing if 0 decisions and 4+ exchanges", () => {
+    const convergence = makeConvergence({
+      exchanges: 5,
+      decisionEvents: [],
+    });
+    const tokenUsage = makeTokenUsage({ totalTokens: 50000 });
+    const result = extractSessionEconomics(null, tokenUsage, convergence);
+    assert.equal(result.thrashingEpisodes.length, 1);
+    assert.equal(result.thrashingEpisodes[0].startExchange, 0);
+    assert.equal(result.thrashingEpisodes[0].endExchange, 4);
+  });
+
+  it("no thrashing if 0 decisions and < 4 exchanges", () => {
+    const convergence = makeConvergence({
+      exchanges: 1,
+      decisionEvents: [],
+    });
+    const result = extractSessionEconomics(null, makeTokenUsage(), convergence);
+    assert.equal(result.thrashingEpisodes.length, 0);
+  });
+});

--- a/src/extractors/session-economics.test.ts
+++ b/src/extractors/session-economics.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import { extractSessionEconomics } from "./session-economics.js";
+import { TokenUsageSignal, ConvergenceSignal } from "../types/pulse.js";
+import { writeFileSync, mkdtempSync, unlinkSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpFiles: string[] = [];
+let tmpDirs: string[] = [];
+
+function createSessionFile(entries: Array<{ type: string; timestamp: string; model?: string; input_tokens?: number; output_tokens?: number }>): string {
+  const dir = mkdtempSync(join(tmpdir(), "pulse-econ-test-"));
+  tmpDirs.push(dir);
+  const filePath = join(dir, "session.jsonl");
+  const lines = entries.map(e => {
+    const obj: any = { type: e.type, timestamp: e.timestamp };
+    if (e.type === "user") {
+      obj.message = { role: "user", content: "test message" };
+    } else {
+      obj.message = { role: "assistant", content: "response" };
+      if (e.model) obj.message.model = e.model;
+      if (e.input_tokens !== undefined || e.output_tokens !== undefined) {
+        obj.message.usage = {
+          input_tokens: e.input_tokens ?? 0,
+          output_tokens: e.output_tokens ?? 0,
+        };
+      }
+    }
+    return JSON.stringify(obj);
+  });
+  writeFileSync(filePath, lines.join("\n") + "\n");
+  tmpFiles.push(filePath);
+  return filePath;
+}
+
+function makeTokenUsage(overrides?: Partial<TokenUsageSignal>): TokenUsageSignal {
+  return {
+    inputTokens: 10000, outputTokens: 5000, totalTokens: 15000,
+    tokensPerExchange: 3000, tokensPerOutcome: 5000, available: true,
+    ...overrides,
+  };
+}
+
+function makeConvergence(overrides?: Partial<ConvergenceSignal>): ConvergenceSignal {
+  return {
+    exchanges: 5, outcomes: 3, rate: 1.67,
+    reworkInstances: 0, reworkPercent: 0,
+    duplicateCommits: 0, blindRetries: 0, pivot: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const f of tmpFiles) { try { unlinkSync(f); } catch {} }
+  for (const d of tmpDirs) { try { rmdirSync(d); } catch {} }
+  tmpFiles = [];
+  tmpDirs = [];
+});
+
+// ── Task 2: Time analysis ─────────────────────────────────────────────────────
+
+describe("extractSessionEconomics - time analysis", () => {
+  it("computes duration from first to last timestamp", () => {
+    const t0 = "2024-01-01T10:00:00.000Z";
+    const t1 = "2024-01-01T10:03:00.000Z";
+    const t2 = "2024-01-01T10:07:00.000Z";
+    const t3 = "2024-01-01T10:11:00.000Z";
+    const filePath = createSessionFile([
+      { type: "user", timestamp: t0 },
+      { type: "assistant", timestamp: t1 },
+      { type: "user", timestamp: t2 },
+      { type: "assistant", timestamp: t3 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.durationMs, 660000);
+  });
+
+  it("detects idle gaps > 5 minutes", () => {
+    const t0 = "2024-01-01T10:00:00.000Z";
+    const t1 = "2024-01-01T10:02:00.000Z";
+    const t2 = "2024-01-01T10:12:00.000Z";
+    const t3 = "2024-01-01T10:14:00.000Z";
+    const filePath = createSessionFile([
+      { type: "user", timestamp: t0 },
+      { type: "assistant", timestamp: t1 },
+      { type: "user", timestamp: t2 },
+      { type: "assistant", timestamp: t3 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.idleGaps, 1);
+    assert.equal(result.idleMs, 600000);
+    assert.equal(result.activeMs, 120000);
+  });
+
+  it("does not flag gaps <= 5 minutes as idle", () => {
+    const t0 = "2024-01-01T10:00:00.000Z";
+    const t1 = "2024-01-01T10:03:00.000Z";
+    const filePath = createSessionFile([
+      { type: "user", timestamp: t0 },
+      { type: "assistant", timestamp: t1 },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.idleGaps, 0);
+  });
+
+  it("returns zero duration for null session path", () => {
+    const result = extractSessionEconomics(null, makeTokenUsage(), makeConvergence());
+    assert.equal(result.durationMs, 0);
+    assert.equal(result.activeMs, 0);
+    assert.equal(result.idleMs, 0);
+    assert.equal(result.idleGaps, 0);
+  });
+
+  it("handles single-message session", () => {
+    const filePath = createSessionFile([
+      { type: "user", timestamp: "2024-01-01T10:00:00.000Z" },
+    ]);
+    const result = extractSessionEconomics(filePath, makeTokenUsage(), makeConvergence());
+    assert.equal(result.durationMs, 0);
+  });
+});

--- a/src/extractors/session-economics.ts
+++ b/src/extractors/session-economics.ts
@@ -74,11 +74,53 @@ export function analyzeTime(timestamps: number[]): TimeAnalysis {
   return { durationMs, activeMs, idleMs, idleGaps };
 }
 
-// ── Placeholders ──────────────────────────────────────────────────────────────
+// ── Thrashing detection ───────────────────────────────────────────────────────
 
-function detectThrashing(_convergence: ConvergenceSignal, _tokenUsage: TokenUsageSignal): ThrashingEpisode[] {
-  return [];
+function makeEpisode(start: number, end: number, exchanges: number, totalExchanges: number, totalTokens: number): ThrashingEpisode {
+  return {
+    startExchange: start,
+    endExchange: end,
+    exchanges,
+    estimatedTokens: totalExchanges > 0 ? Math.round((exchanges / totalExchanges) * totalTokens) : 0,
+  };
 }
+
+function detectThrashing(convergence: ConvergenceSignal, tokenUsage: TokenUsageSignal): ThrashingEpisode[] {
+  const totalExchanges = convergence.exchanges;
+  if (totalExchanges < 4) return [];
+
+  const decisionIndices = new Set(
+    (convergence.decisionEvents ?? []).map(e => e.atExchange)
+  );
+
+  const episodes: ThrashingEpisode[] = [];
+  let runStart: number | null = null;
+
+  for (let i = 0; i < totalExchanges; i++) {
+    if (decisionIndices.has(i)) {
+      if (runStart !== null) {
+        const runLen = i - runStart;
+        if (runLen >= 4) {
+          episodes.push(makeEpisode(runStart, i - 1, runLen, totalExchanges, tokenUsage.totalTokens));
+        }
+      }
+      runStart = null;
+    } else {
+      if (runStart === null) runStart = i;
+    }
+  }
+
+  if (runStart !== null) {
+    const runLen = totalExchanges - runStart;
+    if (runLen >= 4) {
+      episodes.push(makeEpisode(runStart, totalExchanges - 1, runLen, totalExchanges, tokenUsage.totalTokens));
+    }
+  }
+
+  return episodes;
+}
+
+// ── Cost placeholder ──────────────────────────────────────────────────────────
 
 function computeCost(_sessionPath: string | null): number | null {
   return null;

--- a/src/extractors/session-economics.ts
+++ b/src/extractors/session-economics.ts
@@ -120,10 +120,73 @@ function detectThrashing(convergence: ConvergenceSignal, tokenUsage: TokenUsageS
   return episodes;
 }
 
-// ── Cost placeholder ──────────────────────────────────────────────────────────
+// ── Cost model ────────────────────────────────────────────────────────────────
 
-function computeCost(_sessionPath: string | null): number | null {
+const MODEL_PRICING: Array<{ prefix: string; pricing: ModelPricing }> = [
+  { prefix: "claude-opus-4",   pricing: { inputPerMTok: 15,   outputPerMTok: 75  } },
+  { prefix: "claude-sonnet-4", pricing: { inputPerMTok: 3,    outputPerMTok: 15  } },
+  { prefix: "claude-haiku-4",  pricing: { inputPerMTok: 0.80, outputPerMTok: 4   } },
+];
+
+function findPricing(model: string): ModelPricing | null {
+  for (const entry of MODEL_PRICING) {
+    if (model.startsWith(entry.prefix)) return entry.pricing;
+  }
   return null;
+}
+
+interface PerMessageCost {
+  inputTokens: number;
+  outputTokens: number;
+  pricing: ModelPricing;
+}
+
+function readPerMessageCosts(sessionPath: string): PerMessageCost[] | null {
+  try {
+    const content = readFileSync(sessionPath, "utf-8");
+    const results: PerMessageCost[] = [];
+    let anyModel = false;
+
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const obj: RawLine = JSON.parse(line);
+        if (obj.message?.role !== "assistant") continue;
+        const model = obj.message.model;
+        if (!model) continue;
+        anyModel = true;
+        const pricing = findPricing(model);
+        if (!pricing) continue;
+        const usage = obj.message.usage;
+        if (!usage) continue;
+        results.push({
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          pricing,
+        });
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    return anyModel ? results : null;
+  } catch {
+    return null;
+  }
+}
+
+function computeCost(sessionPath: string | null): number | null {
+  if (!sessionPath) return null;
+  const messages = readPerMessageCosts(sessionPath);
+  if (messages === null) return null;
+
+  let total = 0;
+  for (const msg of messages) {
+    total += (msg.inputTokens / 1_000_000) * msg.pricing.inputPerMTok;
+    total += (msg.outputTokens / 1_000_000) * msg.pricing.outputPerMTok;
+  }
+
+  return Math.round(total * 10000) / 10000;
 }
 
 // ── Main extractor ────────────────────────────────────────────────────────────
@@ -162,5 +225,4 @@ export function extractSessionEconomics(
   };
 }
 
-// Suppress unused import warning — ModelPricing will be used in Task 4
-void (0 as unknown as ModelPricing);
+

--- a/src/extractors/session-economics.ts
+++ b/src/extractors/session-economics.ts
@@ -57,19 +57,16 @@ export function analyzeTime(timestamps: number[]): TimeAnalysis {
 
   let idleMs = 0;
   let idleGaps = 0;
-  let lastIdleEnd = sorted[0];
 
   for (let i = 1; i < sorted.length; i++) {
     const gap = sorted[i] - sorted[i - 1];
     if (gap > IDLE_THRESHOLD_MS) {
       idleMs += gap;
       idleGaps += 1;
-      lastIdleEnd = sorted[i];
     }
   }
 
-  // activeMs = time from the end of the last idle gap to the end of the session
-  const activeMs = sorted[sorted.length - 1] - lastIdleEnd;
+  const activeMs = durationMs - idleMs;
 
   return { durationMs, activeMs, idleMs, idleGaps };
 }
@@ -200,11 +197,11 @@ export function extractSessionEconomics(
   const timestamps = sessionPath ? readTimestamps(sessionPath) : [];
   const time = analyzeTime(timestamps);
 
-  // Thrashing (placeholder)
+  // Thrashing detection
   const thrashingEpisodes = detectThrashing(convergence, tokenUsage);
   const thrashingTokens = thrashingEpisodes.reduce((sum, ep) => sum + ep.estimatedTokens, 0);
 
-  // Cost (placeholder)
+  // Dollar cost
   const costDollars = computeCost(sessionPath);
 
   // Tokens per decision

--- a/src/extractors/session-economics.ts
+++ b/src/extractors/session-economics.ts
@@ -1,0 +1,124 @@
+import { SessionEconomicsSignal, ThrashingEpisode, TokenUsageSignal, ConvergenceSignal, ModelPricing } from "../types/pulse.js";
+import { readFileSync } from "node:fs";
+
+const IDLE_THRESHOLD_MS = 5 * 60 * 1000;
+
+// ── JSONL helpers ─────────────────────────────────────────────────────────────
+
+interface RawLine {
+  timestamp?: string;
+  message?: {
+    role?: string;
+    model?: string;
+    usage?: { input_tokens?: number; output_tokens?: number };
+  };
+}
+
+/** Read all timestamps from a JSONL session file. */
+export function readTimestamps(sessionPath: string): number[] {
+  try {
+    const content = readFileSync(sessionPath, "utf-8");
+    const results: number[] = [];
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const obj: RawLine = JSON.parse(line);
+        if (obj.timestamp) {
+          const ms = Date.parse(obj.timestamp);
+          if (!isNaN(ms)) results.push(ms);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+// ── Time analysis ─────────────────────────────────────────────────────────────
+
+interface TimeAnalysis {
+  durationMs: number;
+  activeMs: number;
+  idleMs: number;
+  idleGaps: number;
+}
+
+/** Compute duration/active/idle from a sorted list of timestamps (ms). */
+export function analyzeTime(timestamps: number[]): TimeAnalysis {
+  if (timestamps.length < 2) {
+    return { durationMs: 0, activeMs: 0, idleMs: 0, idleGaps: 0 };
+  }
+
+  const sorted = [...timestamps].sort((a, b) => a - b);
+  const durationMs = sorted[sorted.length - 1] - sorted[0];
+
+  let idleMs = 0;
+  let idleGaps = 0;
+  let lastIdleEnd = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = sorted[i] - sorted[i - 1];
+    if (gap > IDLE_THRESHOLD_MS) {
+      idleMs += gap;
+      idleGaps += 1;
+      lastIdleEnd = sorted[i];
+    }
+  }
+
+  // activeMs = time from the end of the last idle gap to the end of the session
+  const activeMs = sorted[sorted.length - 1] - lastIdleEnd;
+
+  return { durationMs, activeMs, idleMs, idleGaps };
+}
+
+// ── Placeholders ──────────────────────────────────────────────────────────────
+
+function detectThrashing(_convergence: ConvergenceSignal, _tokenUsage: TokenUsageSignal): ThrashingEpisode[] {
+  return [];
+}
+
+function computeCost(_sessionPath: string | null): number | null {
+  return null;
+}
+
+// ── Main extractor ────────────────────────────────────────────────────────────
+
+export function extractSessionEconomics(
+  sessionPath: string | null,
+  tokenUsage: TokenUsageSignal,
+  convergence: ConvergenceSignal
+): SessionEconomicsSignal {
+  // Time analysis
+  const timestamps = sessionPath ? readTimestamps(sessionPath) : [];
+  const time = analyzeTime(timestamps);
+
+  // Thrashing (placeholder)
+  const thrashingEpisodes = detectThrashing(convergence, tokenUsage);
+  const thrashingTokens = thrashingEpisodes.reduce((sum, ep) => sum + ep.estimatedTokens, 0);
+
+  // Cost (placeholder)
+  const costDollars = computeCost(sessionPath);
+
+  // Tokens per decision
+  const decisionCount = convergence.decisionEvents?.length ?? 0;
+  const tokensPerDecision = decisionCount > 0
+    ? Math.round(tokenUsage.totalTokens / decisionCount)
+    : Infinity;
+
+  return {
+    durationMs: time.durationMs,
+    activeMs: time.activeMs,
+    idleMs: time.idleMs,
+    idleGaps: time.idleGaps,
+    thrashingEpisodes,
+    costDollars,
+    tokensPerDecision,
+    thrashingTokens,
+  };
+}
+
+// Suppress unused import warning — ModelPricing will be used in Task 4
+void (0 as unknown as ModelPricing);

--- a/src/types/pulse.ts
+++ b/src/types/pulse.ts
@@ -10,6 +10,9 @@ export interface PulseReport {
   promptEffectiveness: PromptEffectivenessSignal;
   interactionLeverage: "HIGH" | "MEDIUM" | "LOW";
   leverageScore: number;
+  sessionEconomics: SessionEconomicsSignal;
+  sessionROI: number;
+  sessionROILabel: "PRODUCTIVE" | "NEUTRAL" | "EXPENSIVE";
 }
 
 export interface AgentReport {
@@ -60,6 +63,18 @@ export interface ConvergenceSignal {
   pivot: PivotSignal | null;
   /** Per-agent convergence breakdown (only present when MPG data available) */
   agentBreakdown?: AgentConvergenceStats[];
+  /** Decision events detected from user messages (#55) */
+  decisionEvents?: DecisionEvent[];
+}
+
+/** A decision event detected from a user message */
+export interface DecisionEvent {
+  /** Exchange index (0-based) where the decision occurred */
+  atExchange: number;
+  /** Classification of the decision */
+  type: "option_selected" | "scope_decided" | "delegated" | "approved" | "rejected";
+  /** Brief description of what was detected */
+  detail: string;
 }
 
 export interface PivotSignal {
@@ -197,6 +212,43 @@ export interface DecisionQualitySignal {
   externalContextProvided: boolean;
   /** Commit messages from the session */
   commitMessages: string[];
+}
+
+export interface SessionEconomicsSignal {
+  /** Wall-clock duration from first to last message (ms) */
+  durationMs: number;
+  /** Time spent with active exchanges — messages < 5min apart (ms) */
+  activeMs: number;
+  /** Estimated idle time — sum of gaps > 5min (ms) */
+  idleMs: number;
+  /** Number of idle gaps detected */
+  idleGaps: number;
+  /** Thrashing episodes: stretches of 4+ exchanges with no decision events */
+  thrashingEpisodes: ThrashingEpisode[];
+  /** Token cost in dollars (null if model pricing unavailable) */
+  costDollars: number | null;
+  /** Tokens spent per decision event */
+  tokensPerDecision: number;
+  /** Tokens estimated burned during thrashing episodes */
+  thrashingTokens: number;
+}
+
+export interface ThrashingEpisode {
+  /** Exchange range start (inclusive, 0-based) */
+  startExchange: number;
+  /** Exchange range end (inclusive, 0-based) */
+  endExchange: number;
+  /** Number of exchanges in this episode */
+  exchanges: number;
+  /** Estimated tokens consumed — proportional allocation */
+  estimatedTokens: number;
+}
+
+export interface ModelPricing {
+  /** Dollars per million input tokens */
+  inputPerMTok: number;
+  /** Dollars per million output tokens */
+  outputPerMTok: number;
 }
 
 // ── Activity event types (issue #10) ──────────────────────────


### PR DESCRIPTION
## Summary
- **Phase 1 — Decision event detection**: 5 new heuristic patterns (option_selected, scope_decided, delegated, approved, rejected), heredoc commit parsing, time-window scoping fix, MPG agent name resolution
- **Phase 2 — Session Economics**: new `session-economics.ts` extractor with time analysis (duration/active/idle), thrashing detection, dollar cost model (opus/sonnet/haiku prefix-matched pricing), and `computeSessionROI()` composite (PRODUCTIVE/NEUTRAL/EXPENSIVE labels)
- **New report section**: SESSION ECONOMICS with duration, decisions, thrashing, cost, ROI — plus ROI in the summary line alongside Interaction Leverage

## Test plan
- [x] 39 new tests across convergence (decision events, heredoc, agent names) and session-economics (time, thrashing, cost, tokensPerDecision, ROI)
- [x] 288 total tests, 280 pass (8 pre-existing failures unchanged)
- [x] Dogfood validated on 3 real MPG sessions — decision detection 67-175%, ROI labels match intuition ($0.71-$3.82 cost range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)